### PR TITLE
Fix parser version comment

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -1,4 +1,4 @@
-// 🧠 Blang parser v0.9.3 - 自動補宣告 + 條件語句語意優化整合版
+// 🧠 Blang parser v0.9.4 - 自動補宣告 + 條件語句語意優化整合版
 const fs = require('fs');
 const {
   processDisplayArgument,


### PR DESCRIPTION
## Summary
- update comment in `parser_v0.9.4.js` to match file version

## Testing
- `node parser_v0.9.4.js`

------
https://chatgpt.com/codex/tasks/task_e_68442068a33c8327a5c7ed050fed456c