### PR TITLE
Fix array module path in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <div id="name_display"></div>
 
     <!-- 模組載入順序建議：先載 array，再載核心邏輯 -->
-    <script src="blang-modules/array-loader.js"></script>
+    <script src="blang-modules/array.js"></script>
     <script src="output.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- correct script path in the demo page

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/blang-modules/array.js`


------
https://chatgpt.com/codex/tasks/task_e_68442391e9008327ba2d09852584f9ba