### PR TITLE
Add minimal Node.js tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "blang-language",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node tests/run-tests.js"
+  }
+}

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const fs = require('fs');
+const { execSync } = require('child_process');
+const { processDisplayArgument } = require('../semanticHandler-v0.9.4.js');
+
+function testProcessDisplayArgument() {
+  const declaredVars = new Set(['key']);
+  assert.strictEqual(processDisplayArgument('紅色'), '"red"');
+  assert.strictEqual(processDisplayArgument('obj[key]', declaredVars), 'obj[key]');
+  assert.strictEqual(processDisplayArgument('obj[key]'), 'obj["key"]');
+}
+
+function testParser() {
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('alert("請先輸入內容");'),
+    'alert line should be parsed'
+  );
+  assert(
+    output.includes('document.querySelector("#結果區").style["backgroundColor"] = "red";'),
+    'style line should be parsed with color keyword'
+  );
+}
+
+try {
+  testProcessDisplayArgument();
+  testParser();
+  console.log('All tests passed');
+} catch (err) {
+  console.error('Test failed:\n', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- introduce `tests/` with a small Node-based test script
- add `package.json` to run the tests via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68442548a5c083278c8ace17f207e01c