### PR TITLE
Fix content length condition handling

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -113,9 +113,7 @@ function processCondition(condition) {
     (_, arg) => `${arg.trim()}.length === 0`
   );
 
-  result = processConditionExpression(result)
-    // 補強未在 processConditionExpression 中處理的片段
-    .replace(/內容長度/g, 'value.length');
+  result = processConditionExpression(result);
   return result;
 }
 

--- a/semanticHandler-v0.9.4.js
+++ b/semanticHandler-v0.9.4.js
@@ -67,6 +67,7 @@ function processConditionExpression(str) {
     .replace(/（/g, '(')
     .replace(/）/g, ')')
     .replace(/。/g, '.') // 中文句號有時出現在成員存取
+    .replace(/內容長度/g, 'value.length')
     .replace(/長度/g, 'length')
     .replace(/內容/g, 'value')
     .replace(/大於等於/g, '>=')

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -53,10 +53,34 @@ function testConditionProcessing() {
   }
 }
 
+function testContentLengthCondition() {
+  const sample = '如果（字串.內容長度 > 3）：顯示("ok")';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('if (字串.value.length > 3)'),
+    '內容長度 should become value.length in condition'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 try {
   testProcessDisplayArgument();
   testParser();
   testConditionProcessing();
+  testContentLengthCondition();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);


### PR DESCRIPTION
## Summary
- handle `內容長度` inside `processConditionExpression`
- simplify `processCondition` accordingly
- add test for parsing `內容長度`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846d9d090348327abc8cdf2526c08a7