### PR TITLE
Fix toggle color block in parser

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -395,9 +395,11 @@ for (let i = 0; i < lines.length; i++) {
       const sel = processDisplayArgument(m[1].trim(), declaredVars);
       const c1 = processDisplayArgument(m[2].trim(), declaredVars);
       const c2 = processDisplayArgument(m[3].trim(), declaredVars);
-      output.push(' '.repeat(indent) + `const __el = document.querySelector(${sel});`);
-      output.push(' '.repeat(indent) + `const __el = document.querySelector(${sel});`);
-      output.push(' '.repeat(indent) + `__el.style.color = __el.style.color === ${c1} ? ${c2} : ${c1};`);
+      output.push(
+        ' '.repeat(indent) +
+          `document.querySelector(${sel}).style.color = ` +
+          `document.querySelector(${sel}).style.color === ${c1} ? ${c2} : ${c1};`
+      );
       continue;
     }
   }

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -53,10 +53,35 @@ function testConditionProcessing() {
   }
 }
 
+function testToggleColor() {
+  const sample = '切換顏色(#結果區, 紅色, 藍色)\n切換顏色(#結果區, 紅色, 藍色)';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+
+  const expected =
+    'document.querySelector("#結果區").style.color = document.querySelector("#結果區").style.color === "red" ? "blue" : "red";';
+  const count = output.split('\n').filter((l) => l.trim() === expected).length;
+  assert.strictEqual(count, 2, 'should generate two toggle color lines');
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 try {
   testProcessDisplayArgument();
   testParser();
   testConditionProcessing();
+  testToggleColor();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);


### PR DESCRIPTION
## Summary
- inline querySelector usage in the `切換顏色` block
- add a parser test for consecutive `切換顏色()` lines

## Testing
- `npm test --silent`
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6846dc0b7e94832796e053d674d1193d