### PR TITLE
Add tests for querySelector quoting

### DIFF
--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -53,10 +53,62 @@ function testConditionProcessing() {
   }
 }
 
+function testHideElementParsing() {
+  const sample = '隱藏元素(#test)';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('document.querySelector("#test").style.display = "none";'),
+    '隱藏元素 should convert to querySelector with quoted selector'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
+function testToggleColorParsing() {
+  const sample = '切換顏色(#foo, 紅色, 藍色)';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('const __el = document.querySelector("#foo");'),
+    '切換顏色 should use querySelector with quoted selector'
+  );
+  assert(
+    output.includes('__el.style.color = __el.style.color === "red" ? "blue" : "red";'),
+    '切換顏色 should toggle colors correctly'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 try {
   testProcessDisplayArgument();
   testParser();
   testConditionProcessing();
+  testHideElementParsing();
+  testToggleColorParsing();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);


### PR DESCRIPTION
## Summary
- test parser output for 隱藏元素 and 切換顏色
- ensure selectors are quoted in generated querySelector calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846dccf3f888327a70b0afe9728e752