### PR TITLE
Fix 空 condition parsing

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -52,7 +52,11 @@ function processCondition(condition) {
     (_, arg) => `${arg.trim()}.length === 0`
   );
 
-  result = processConditionExpression(result);
+  // 直接處理「為 空」情境
+  result = result.replace(/為\s*空/g, '=== 空');
+
+  result = processConditionExpression(result)
+    .replace(/(===|!==|==|!=)\s*空/g, '$1 ""');
 
   return result;
 }
@@ -113,6 +117,9 @@ function processCondition(condition) {
     /判斷是否為空\s*\(\s*(.*?)\s*\)/g,
     (_, arg) => `${arg.trim()}.length === 0`
   );
+
+  // 直接處理「為 空」情境
+  result = result.replace(/為\s*空/g, '=== 空');
 
   result = processConditionExpression(result)
     // 補強未在 processConditionExpression 中處理的片段

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -103,12 +103,37 @@ function testToggleColorParsing() {
   }
 }
 
+function testEmptyComparison() {
+  const sample = '如果（輸入框 為 空）：';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('if (輸入框 === "")'),
+    '為 空 should convert to comparison with empty string'
+  );
+  assert(!output.includes('let 空'), 'should not declare variable named 空');
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 try {
   testProcessDisplayArgument();
   testParser();
   testConditionProcessing();
   testHideElementParsing();
   testToggleColorParsing();
+  testEmptyComparison();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);


### PR DESCRIPTION
## Summary
- treat `為 空` / `=== 空` as comparisons to an empty string
- extend ignore list to skip `空`
- test that parsing `如果（輸入框 為 空）：` compares with "" and doesn't declare `空`

## Testing
- `npm test --silent` *(fails: 切換顏色 should use querySelector with quoted selector)*

------
https://chatgpt.com/codex/tasks/task_e_6846e39c22548327902df268c14e2172