### PR TITLE
Fix hide element rule to use querySelector

### DIFF
--- a/output.js
+++ b/output.js
@@ -62,7 +62,7 @@ if (數量 > 2) {
         alert("清單是空的");
         let __toggleEl0 = document.querySelector("#結果區");
         __toggleEl0.style.color = __toggleEl0.style.color === "red" ? "blue" : "red";
-                "#歡迎區".style.display = 'none';
+        document.querySelector("#歡迎區").style.display = "none";
                 影片播放器.play();
                 音效播放器.pause();
         alert("現在時間是：" + new Date().toLocaleTimeString());

--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -192,6 +192,11 @@ for (let i = 0; i < lines.length; i++) {
     if (match) {
       const funcName = match[1].trim();
       const params = match[2].trim();
+      if (funcName === '隱藏元素') {
+        const sel = processDisplayArgument(params, declaredVars);
+        output.push(' '.repeat(indent) + `document.querySelector(${sel}).style.display = "none";`);
+        continue;
+      }
       output.push(' '.repeat(indent) + handleFunctionCall(funcName, params, indent, declaredVars));
       continue;
     }


### PR DESCRIPTION
## Summary
- wrap `隱藏元素` arguments in `document.querySelector` when invoked via `呼叫`
- recompile `demo.blang` with parser to update `output.js`

## Testing
- `npm test`
- `node parser_v0.9.4.js`

------
https://chatgpt.com/codex/tasks/task_e_6847a460064083278f3366a4fe7e6a53