### PR TITLE
Fix quoting for 替換文字

### DIFF
--- a/output.js
+++ b/output.js
@@ -67,7 +67,7 @@ if (數量 > 2) {
                 音效播放器.pause();
         alert("現在時間是：" + new Date().toLocaleTimeString());
         let 原句 = '我喜歡貓';
-        alert(原句.replace(貓, 狗));
+        alert(原句.replace("貓", "狗"));
         window.location.href = "https://example.com";
     }
     }

--- a/semanticHandler-v0.9.4.js
+++ b/semanticHandler-v0.9.4.js
@@ -156,7 +156,13 @@ function processDisplayArgument(arg, declaredVars = new Set()) {
       const args = extractArguments(arg, phrase);
       if (!args) break;
       const cleanArgs = args.map((p) => {
-        const raw = p.trim().replace(/^"|"$/g, '');
+        const trimmed = p.trim();
+        const raw = trimmed.replace(/^\s*["“”'']|["“”'']\s*$/g, '');
+
+        if (phrase === '替換文字' && /^['"“”].*['"“”]$/.test(trimmed)) {
+          return `"${raw}"`;
+        }
+
         if (colorMap[raw]) {
           return `"${colorMap[raw]}"`;
         }


### PR DESCRIPTION
## Summary
- preserve literal string arguments in `替換文字`
- regenerate `output.js`

## Testing
- `node tests/run-tests.js`
- `node parser_v0.9.4.js`

------
https://chatgpt.com/codex/tasks/task_e_6847a6074284832785fa37afae0079f0