### PR TITLE
Fix indentation closing logic in parser

### DIFF
--- a/output.js
+++ b/output.js
@@ -27,9 +27,6 @@ if (輸入框.value === "") {
     let 數量 = 3;
 if (數量 > 2) {
     alert("超過兩個！");
-}
-}
-});
     for (let i = 0; i < 3; i++) {
         alert("你好");
         let 分數 = 85;
@@ -71,3 +68,6 @@ if (數量 > 2) {
         window.location.href = "https://example.com";
     }
     }
+}
+}
+});

--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -26,11 +26,11 @@ function getIndentLevel(line) {
 
 function closeBlocks(currentIndent, nextIndent, upcomingLine = '') {
   const isTopLevel =
-    upcomingLine.startsWith('當(') ||
-    upcomingLine.startsWith('變數 ') ||
-    upcomingLine.startsWith('定義 ') ||
-    upcomingLine.startsWith('重複執行(') ||
-    upcomingLine === '';
+    currentIndent === 0 &&
+    (upcomingLine.startsWith('當(') ||
+      upcomingLine.startsWith('變數 ') ||
+      upcomingLine.startsWith('定義 ') ||
+      upcomingLine === '');
 
   if (isTopLevel) {
     while (stack.length > 0) {


### PR DESCRIPTION
## Summary
- refine `closeBlocks` to only flush stack on top-level lines
- regenerate `output.js` so the loop stays nested inside the `如果（數量 > 2）` block

## Testing
- `node parser_v0.9.4.js`
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6847a812da1c83279a48b903336afe60