### PR TITLE
Remove duplicate function definition

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -48,19 +48,6 @@ function closeBlocks(currentIndent, nextIndent, upcomingLine = '') {
     output.push(' '.repeat(block.indent) + closing + ` // 👈 自動關閉 ${block.type} 區塊`);
   }
 }
-function processCondition(condition) {
-  let result = condition.replace(
-    /判斷是否為空[（(](.*?)?[)）]/g,
-    (_, arg) => `${arg.trim()}.length === 0`
-  );
-
-  // 先處理內容長度，以免在後續轉換時遺漏
-  result = result.replace(/內容長度/g, 'value.length');
-
-  result = processConditionExpression(result);
-
-  return result;
-}
 
 const ignoreList = new Set([
   'document',


### PR DESCRIPTION
## Summary
- clean up parser by removing duplicated `processCondition` function definition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847cc6445588327a9467642aba46671