### PR TITLE
Add sound module integration and tests

### DIFF
--- a/semanticHandler-v0.9.4.js
+++ b/semanticHandler-v0.9.4.js
@@ -9,6 +9,7 @@ const styleModule = require('./styleModule.js');
 const imageModule = require('./imageModule.js');
 const logModule = require('./logModule.js');
 const mediaModule = require('./mediaModule.js');
+const soundModule = require('./soundModule.js');
 const vocabularyMap = require('./vocabulary_map.json');
 const colorMap = require('./colorMap.js');
 
@@ -21,7 +22,8 @@ const modules = {
   styleModule,
   imageModule,
   logModule,
-  mediaModule
+  mediaModule,
+  soundModule
 };
 /***** 中文函式 → FQN 對應 *****/
 const FUNC_MAP = {
@@ -31,7 +33,7 @@ const FUNC_MAP = {
   顯示第幾項: 'ArrayModule.顯示第幾項',
   'AI 回覆': 'DialogModule.AI回覆',
   顯示訊息框: 'DialogModule.顯示訊息框',
-  播放音效: 'SoundModule.播放音效',
+  播放音效: 'soundModule.播放音效',
   設定樣式: 'StyleModule.設定樣式'
 };
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -238,6 +238,29 @@ function testPauseAudioParsing() {
   }
 }
 
+function testPlaySoundParsing() {
+  const sample = '播放音效("ding.mp3")';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('new Audio("ding.mp3").play();'),
+    '播放音效 should translate to new Audio().play()'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 try {
   testProcessDisplayArgument();
   testParser();
@@ -249,6 +272,7 @@ try {
   testLogStatement();
   testPlayVideoParsing();
   testPauseAudioParsing();
+  testPlaySoundParsing();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);


### PR DESCRIPTION
## Summary
- register `soundModule` in semantic handler
- map `播放音效` to `soundModule.播放音效`
- add unit test for `播放音效("ding.mp3")`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847d03e93f483278a70e255db72de96