### PR TITLE
Add weekday/time translations

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -458,6 +458,22 @@ for (let i = 0; i < lines.length; i++) {
     continue;
   }
 
+  if (line.trim() === '顯示今天是星期幾') {
+    output.push(
+      ' '.repeat(indent) +
+        'alert("今天是星期" + "日一二三四五六"[new Date().getDay()]);'
+    );
+    continue;
+  }
+
+  if (line.trim() === '顯示現在是幾點幾分') {
+    output.push(
+      ' '.repeat(indent) +
+        'alert("現在是" + new Date().getHours() + "點" + new Date().getMinutes() + "分");'
+    );
+    continue;
+  }
+
   if (line.match(/^替換文字[（(].*[)）]$/)) {
     const m = line.match(/替換文字[（(](.*?),\s*(.*?),\s*(.*)[)）]/);
     if (m) {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -284,6 +284,52 @@ function testPlaySoundParsing() {
   }
 }
 
+function testDisplayWeekday() {
+  const sample = '顯示今天是星期幾';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('今天是星期'),
+    '顯示今天是星期幾 should produce alert with weekday'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
+function testDisplayHourMinute() {
+  const sample = '顯示現在是幾點幾分';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('現在是'),
+    '顯示現在是幾點幾分 should produce alert with hour and minute'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 try {
   testProcessDisplayArgument();
   testParser();
@@ -297,6 +343,8 @@ try {
   testPlayVideoParsing();
   testPauseAudioParsing();
   testPlaySoundParsing();
+  testDisplayWeekday();
+  testDisplayHourMinute();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);

--- a/timeModule.js
+++ b/timeModule.js
@@ -1,4 +1,8 @@
 module.exports = {
   獲取現在時間: () => 'new Date().toLocaleTimeString()',
-  顯示現在時間: () => 'alert(new Date().toLocaleString())'
+  顯示現在時間: () => 'alert(new Date().toLocaleString())',
+  顯示今天是星期幾: () =>
+    'alert("今天是星期" + "日一二三四五六"[new Date().getDay()])',
+  顯示現在是幾點幾分: () =>
+    'alert("現在是" + new Date().getHours() + "點" + new Date().getMinutes() + "分")'
 };

--- a/vocabulary_map.json
+++ b/vocabulary_map.json
@@ -91,6 +91,14 @@
         "module": "timeModule",
         "js": "alert(new Date().toLocaleString())"
     },
+    "顯示今天是星期幾": {
+        "module": "timeModule",
+        "js": "alert(\"今天是星期\" + \"日一二三四五六\"[new Date().getDay()])"
+    },
+    "顯示現在是幾點幾分": {
+        "module": "timeModule",
+        "js": "alert(\"現在是\" + new Date().getHours() + \"點\" + new Date().getMinutes() + \"分\")"
+    },
     "替換文字": {
         "module": "stringModule",
         "js": "$1.replace($2, $3)"


### PR DESCRIPTION
## Summary
- support `顯示今天是星期幾` and `顯示現在是幾點幾分`
- expand `timeModule` with helpers
- map new phrases in `vocabulary_map.json`
- update parser to emit JS for the phrases
- test coverage for new rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495be884648327878d0e13943cdbbd