### PR TITLE
Enhance syntax API registry

### DIFF
--- a/customBlangPatterns.js
+++ b/customBlangPatterns.js
@@ -1,5 +1,5 @@
 module.exports = function registerPatterns(definePattern) {
-  definePattern('顯示 $內容', (內容) => `alert(${內容});`);
-  definePattern('設定 $變數 為 $值', (變數, 值) => `let ${變數} = ${值};`);
+  definePattern('顯示 $內容', (內容) => `alert(${內容});`, {});
+  definePattern('設定 $變數 為 $值', (變數, 值) => `let ${變數} = ${值};`, {});
   // 更多擴充語法可加入這裡
 };


### PR DESCRIPTION
## Summary
- allow patterns to record extra options
- auto-close control blocks when parsing
- expose `getRegisteredPatterns`
- update custom pattern registrations to new signature

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_684a9fb3559c8327a5bbf901ffa5ba2b