### PR TITLE
Add conditional display with else

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -345,6 +345,21 @@ for (let i = 0; i < lines.length; i++) {
     }
   }
 
+  if (line.match(/^若[（(](.*?)[）)]則 顯示[（(](.*?)[）)] 否則 顯示[（(](.*?)[）)]$/)) {
+    const match = line.match(/^若[（(](.*?)[）)]則 顯示[（(](.*?)[）)] 否則 顯示[（(](.*?)[）)]$/);
+    if (match) {
+      const condition = processCondition(match[1]);
+      const truthy = match[2].trim();
+      const falsy = match[3].trim();
+      autoDeclareVariablesFromCondition(condition);
+      output.push(
+        ' '.repeat(indent) +
+        `if (${condition}) { alert(${processDisplayArgument(truthy, declaredVars)}); } else { alert(${processDisplayArgument(falsy, declaredVars)}); }`
+      );
+      continue;
+    }
+  }
+
   if (line.match(/^顯示[（(]"(.*?)" 在輸入框上[）)]$/)) {
     const match = line.match(/^顯示[（(]"(.*?)" 在輸入框上[）)]$/);
     if (match) {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -341,6 +341,17 @@ function testIfElsePattern() {
   );
 }
 
+function testIfElsePatternChinese() {
+  const { runBlangParser } = require('../blangSyntaxAPI.js');
+  const lines = ['若 (1 > 0) 則 顯示 ("大") 否則 顯示 ("小")'];
+  const result = runBlangParser(lines).trim();
+  assert.strictEqual(
+    result,
+    'if (1 > 0) { alert("大"); } else { alert("小"); }',
+    'custom pattern should translate to if...else structure with Chinese text'
+  );
+}
+
 try {
   testProcessDisplayArgument();
   testParser();
@@ -357,6 +368,7 @@ try {
   testDisplayWeekday();
   testDisplayHourMinute();
   testIfElsePattern();
+  testIfElsePatternChinese();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);


### PR DESCRIPTION
## Summary
- support `若(條件)則 顯示(內容) 否則 顯示(內容)` in legacy parser
- test the new pattern with Chinese output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa783cea0832786a1855779f583ad