### PR TITLE
Document getRegisteredPatterns API and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ definePattern(
 );
 ```
 
+要查看所有已註冊的語法模式，可使用 `getRegisteredPatterns()`：
+
+```js
+const { getRegisteredPatterns } = require('./blangSyntaxAPI.js');
+console.log(getRegisteredPatterns());
+// 返回陣列列出每個 pattern 及其 {type}
+```
+
 執行轉譯：
 
 ```bash

--- a/grammar.md
+++ b/grammar.md
@@ -72,6 +72,14 @@ definePattern(
 );
 ```
 
+若想列出目前載入的語法模式，可調用 `getRegisteredPatterns()`：
+
+```js
+const { getRegisteredPatterns } = require('./blangSyntaxAPI.js');
+console.log(getRegisteredPatterns());
+// 會顯示 pattern 字串以及對應的 {type}
+```
+
 ---
 
 ## 🧠 語義模組與自動宣告機制（v0.9.4）

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -352,6 +352,24 @@ function testIfElsePatternChinese() {
   );
 }
 
+function testGetRegisteredPatterns() {
+  const { getRegisteredPatterns } = require('../blangSyntaxAPI.js');
+  const patterns = getRegisteredPatterns();
+  const patternStrings = patterns.map(p => p.pattern);
+  const expected = [
+    '顯示 $內容',
+    '設定 $變數 為 $值',
+    '若 $條件 則 顯示 $當真 否則 顯示 $當假',
+    '若（$條件）則 顯示（$語句1） 否則 顯示（$語句2）',
+    '若($條件)則 顯示($語句1) 否則 顯示($語句2)'
+  ];
+  expected.forEach(pat => {
+    assert(patternStrings.includes(pat), `registered patterns should include "${pat}"`);
+  });
+  const ctrl = patterns.find(p => p.pattern === '若 $條件 則 顯示 $當真 否則 顯示 $當假');
+  assert(ctrl && ctrl.type === 'control', 'pattern should expose type property');
+}
+
 try {
   testProcessDisplayArgument();
   testParser();
@@ -369,6 +387,7 @@ try {
   testDisplayHourMinute();
   testIfElsePattern();
   testIfElsePatternChinese();
+  testGetRegisteredPatterns();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);


### PR DESCRIPTION
## Summary
- document `getRegisteredPatterns()` usage in README and grammar
- test the new API in the unit test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fdb019f4c83278f00b7e0ca9fadc7