### PR TITLE
Map getRegisteredPatterns result to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ definePattern(
 );
 ```
 
-<<<<<<< codex/extend-blangsyntaxapi.js-to-group-patterns
-可在第三個參數傳入 `{ type }` 以標記模式用途。常見分類包含：
+可在第三個參數傳入 `{ type, description }` 以標記模式用途與說明。常見分類包含：
 
 - `ui`：介面與 DOM 操作
 - `control`：流程控制語句
@@ -40,15 +39,13 @@ definePattern(
 - `misc`：其他輔助指令
 
 在程式中可使用 `getPatternsByType(type)` 取得同類型的所有已註冊語法。
-=======
-要查看所有已註冊的語法模式，可使用 `getRegisteredPatterns()`：
+若要查看所有已註冊的語法模式，可使用 `getRegisteredPatterns()`：
 
 ```js
 const { getRegisteredPatterns } = require('./blangSyntaxAPI.js');
 console.log(getRegisteredPatterns());
-// 返回陣列列出每個 pattern 及其 {type}
+// 返回類似 [{ pattern, type, description }]
 ```
->>>>>>> main
 
 執行轉譯：
 

--- a/blangSyntaxAPI.js
+++ b/blangSyntaxAPI.js
@@ -89,7 +89,7 @@ function buildRegexFromPattern(pattern) {
 }
 
 function getRegisteredPatterns() {
-  return patternRegistry;
+  return patternRegistry.map(({ pattern, type, description }) => ({ pattern, type, description }));
 }
 
 function getPatternsByType(type) {

--- a/grammar.md
+++ b/grammar.md
@@ -77,7 +77,7 @@ definePattern(
 ```js
 const { getRegisteredPatterns } = require('./blangSyntaxAPI.js');
 console.log(getRegisteredPatterns());
-// 會顯示 pattern 字串以及對應的 {type}
+// 會顯示 pattern 字串以及對應的 { type, description }
 ```
 
 ---

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -437,6 +437,9 @@ function testGetRegisteredPatterns() {
   });
   const ctrl = patterns.find(p => p.pattern === '若 $條件 則 顯示 $當真 否則 顯示 $當假');
   assert(ctrl && ctrl.type === 'control', 'pattern should expose type property');
+  patterns.forEach(p => {
+    assert('description' in p, 'returned pattern objects should include description property');
+  });
 }
 
 try {


### PR DESCRIPTION
## Summary
- clean README conflict markers and document updated API output
- document API output change in grammar.md
- expose pattern metadata in `getRegisteredPatterns`
- verify description field exists in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fe860fab48327b08c1082df10e07f