### PR TITLE
Clean up custom pattern placeholders

### DIFF
--- a/customBlangPatterns.js
+++ b/customBlangPatterns.js
@@ -111,79 +111,34 @@ module.exports = function registerPatterns(definePattern) {
     { type: 'control', description: 'delay message in ms' }
   );
   // 更多擴充語法可加入這裡
-  definePattern(
-    '重複執行($參數1)',
-    (參數1) => // TODO,
-    { type: 'control' }
-  );
-  definePattern(
-    '設定樣式($參數1, $參數2, $參數3)',
-    (參數1, 參數2, 參數3) => // TODO,
-    { type: 'ui' }
-  );
-  definePattern(
-    '切換顏色($參數1, $參數2, $參數3)',
-    (參數1, 參數2, 參數3) => // TODO,
-    { type: 'control' }
-  );
-  definePattern(
-    '轉跳網頁($參數1)',
-    (參數1) => // TODO,
-    { type: 'control' }
-  );
-  definePattern(
-    '顯示圖片($參數1)',
-    (參數1) => // TODO,
-    { type: 'media' }
-  );
-  definePattern(
-    '說一句話($參數1)',
-    (參數1) => // TODO,
-    { type: 'control' }
-  );
-  definePattern(
-    '播放音效($參數1)',
-    (參數1) => new Audio(參數1).play();,
-    { type: 'media' }
-  );
-  definePattern(
-    '隱藏($參數1)',
-    (參數1) => document.querySelector(參數1).style.display = "none";,
-    { type: 'ui' }
-  );
-  definePattern(
-    '設定背景色($參數1, $參數2)',
-    (參數1, 參數2) => document.querySelector(參數1).style.backgroundColor = 參數2;,
-    { type: 'ui' }
-  );
 definePattern(
   '重複執行($參數1)',
-  (參數1) => { return // TODO; },
+  (參數1) => { return; },
   { type: 'control' }
 );
 definePattern(
   '設定樣式($參數1, $參數2, $參數3)',
-  (參數1, 參數2, 參數3) => { return // TODO; },
+  (參數1, 參數2, 參數3) => { return; },
   { type: 'ui' }
 );
 definePattern(
   '切換顏色($參數1, $參數2, $參數3)',
-  (參數1, 參數2, 參數3) => { return // TODO; },
+  (參數1, 參數2, 參數3) => { return; },
   { type: 'control' }
 );
 definePattern(
   '轉跳網頁($參數1)',
-  (參數1) => { return // TODO; },
+  (參數1) => { return; },
   { type: 'control' }
 );
 definePattern(
   '顯示圖片($參數1)',
-  (參數1) => { return // TODO; },
+  (參數1) => { return; },
   { type: 'media' }
 );
 definePattern(
   '說一句話($參數1)',
-  (參數1) => { return // TODO; },
+  (參數1) => { return; },
   { type: 'control' }
 );
 definePattern(


### PR DESCRIPTION
## Summary
- remove old placeholder patterns that had invalid syntax
- keep the final `{ return ... }` stubs and make them parse

## Testing
- `node -c customBlangPatterns.js`


------
https://chatgpt.com/codex/tasks/task_e_684ff3d44978832793c8085e4e7ff0e4