### PR TITLE
Fix pattern snippet generation

### DIFF
--- a/customBlangPatterns.js
+++ b/customBlangPatterns.js
@@ -111,94 +111,49 @@ module.exports = function registerPatterns(definePattern) {
     { type: 'control', description: 'delay message in ms' }
   );
   // 更多擴充語法可加入這裡
-  definePattern(
-    '重複執行($參數1)',
-    (參數1) => // TODO,
-    { type: 'control' }
-  );
-  definePattern(
-    '設定樣式($參數1, $參數2, $參數3)',
-    (參數1, 參數2, 參數3) => // TODO,
-    { type: 'ui' }
-  );
-  definePattern(
-    '切換顏色($參數1, $參數2, $參數3)',
-    (參數1, 參數2, 參數3) => // TODO,
-    { type: 'control' }
-  );
-  definePattern(
-    '轉跳網頁($參數1)',
-    (參數1) => // TODO,
-    { type: 'control' }
-  );
-  definePattern(
-    '顯示圖片($參數1)',
-    (參數1) => // TODO,
-    { type: 'media' }
-  );
-  definePattern(
-    '說一句話($參數1)',
-    (參數1) => // TODO,
-    { type: 'control' }
-  );
-  definePattern(
-    '播放音效($參數1)',
-    (參數1) => new Audio(參數1).play();,
-    { type: 'media' }
-  );
-  definePattern(
-    '隱藏($參數1)',
-    (參數1) => document.querySelector(參數1).style.display = "none";,
-    { type: 'ui' }
-  );
-  definePattern(
-    '設定背景色($參數1, $參數2)',
-    (參數1, 參數2) => document.querySelector(參數1).style.backgroundColor = 參數2;,
-    { type: 'ui' }
-  );
 definePattern(
   '重複執行($參數1)',
-  (參數1) => { return // TODO; },
+  (參數1) => { return /* TODO */; },
   { type: 'control' }
 );
 definePattern(
   '設定樣式($參數1, $參數2, $參數3)',
-  (參數1, 參數2, 參數3) => { return // TODO; },
+  (參數1, 參數2, 參數3) => { return /* TODO */; },
   { type: 'ui' }
 );
 definePattern(
   '切換顏色($參數1, $參數2, $參數3)',
-  (參數1, 參數2, 參數3) => { return // TODO; },
+  (參數1, 參數2, 參數3) => { return /* TODO */; },
   { type: 'control' }
 );
 definePattern(
   '轉跳網頁($參數1)',
-  (參數1) => { return // TODO; },
+  (參數1) => { return /* TODO */; },
   { type: 'control' }
 );
 definePattern(
   '顯示圖片($參數1)',
-  (參數1) => { return // TODO; },
+  (參數1) => { return /* TODO */; },
   { type: 'media' }
 );
 definePattern(
   '說一句話($參數1)',
-  (參數1) => { return // TODO; },
+  (參數1) => { return /* TODO */; },
   { type: 'control' }
 );
 definePattern(
   '播放音效($參數1)',
-  (參數1) => { return new Audio(參數1).play();; },
+  (參數1) => { return new Audio(參數1).play(); },
   { type: 'media' }
 );
 definePattern(
   '隱藏($參數1)',
-  (參數1) => { return document.querySelector(參數1).style.display = "none";; },
+  (參數1) => { return document.querySelector(參數1).style.display = "none"; },
   { type: 'ui' }
 );
 definePattern(
   '設定背景色($參數1, $參數2)',
-  (參數1, 參數2) => { return document.querySelector(參數1).style.backgroundColor = 參數2;; },
+  (參數1, 參數2) => { return document.querySelector(參數1).style.backgroundColor = 參數2; },
   { type: 'ui' }
 );
 };

--- a/scripts/extractPatterns.js
+++ b/scripts/extractPatterns.js
@@ -36,7 +36,7 @@ function generatorCode(cmd, vars) {
   if (/隱藏/.test(cmd)) return `document.querySelector(${vars[0]}).style.display = "none";`;
   if (/設定背景色/.test(cmd))
     return `document.querySelector(${vars[0]}).style.backgroundColor = ${vars[1]};`;
-  return '// TODO';
+  return '/* TODO */';
 }
 
 let custom = fs.readFileSync(patternsPath, 'utf8');
@@ -50,7 +50,13 @@ Object.entries(commands).forEach(([cmd, { argsCount }]) => {
   if (hasPattern(custom, cmd)) return;
   const vars = Array.from({ length: Math.max(argsCount, 1) }, (_, i) => `參數${i + 1}`);
   const pattern = `${cmd}(${vars.map((v) => '$' + v).join(', ')})`;
-  const body = generatorCode(cmd, vars);
+  let body = generatorCode(cmd, vars);
+  if (typeof body === 'string') {
+    body = body.trim().replace(/;$/, '');
+    if (/,\s*$/.test(body)) {
+      console.warn(`generated body for ${cmd} ends with comma`);
+    }
+  }
   const type = guessType(cmd);
   const snippet = [
     `definePattern(`,


### PR DESCRIPTION
## Summary
- trim trailing `;` from generated bodies when extracting patterns
- warn if generated body ends with `,`
- use `/* TODO */` placeholder so snippets compile
- regenerate custom patterns

## Testing
- `npm test`
- `node -c customBlangPatterns.js`


------
https://chatgpt.com/codex/tasks/task_e_684ff3d5c8988327814b3ba4935cdfdc