### PR TITLE
Add current time pattern

### DIFF
--- a/customBlangPatterns.js
+++ b/customBlangPatterns.js
@@ -106,6 +106,11 @@ module.exports = function registerPatterns(definePattern) {
     { type: 'control', description: 'show current time' }
   );
   definePattern(
+    '顯示現在時間',
+    () => 'alert(new Date().toLocaleString());',
+    { type: 'time' }
+  );
+  definePattern(
     '等待 $毫秒 毫秒後 顯示 $訊息',
     (毫秒, 訊息) => `setTimeout(() => alert(${訊息}), ${毫秒});`,
     { type: 'control', description: 'delay message in ms' }


### PR DESCRIPTION
## Summary
- add `顯示現在時間` pattern for showing full date and time
- ensure date and time patterns remain in `customBlangPatterns.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffdbf0ad08327950317cef1acb443