### PR TITLE
Add pattern for selector text content

### DIFF
--- a/customBlangPatterns.js
+++ b/customBlangPatterns.js
@@ -1,3 +1,4 @@
+const { handleFunctionCall } = require('./semanticHandler-v0.9.4.js');
 module.exports = function registerPatterns(definePattern) {
   // 💬 基本輸出語法
   definePattern('顯示 $內容', (內容) => `alert(${內容});`, {
@@ -264,6 +265,11 @@ definePattern(
     '設定文字於 $選擇器 為 $文字',
     (選擇器, 文字) => `document.querySelector(${選擇器}).textContent = ${文字};`,
     { type: 'ui', description: 'set text content' }
+  );
+  definePattern(
+    '設定（$選擇器）為 $內容',
+    (選擇器, 內容) => handleFunctionCall('設定文字內容', `${選擇器}, ${內容}`),
+    { type: 'ui' }
   );
   definePattern(
     '在控制台輸出 $內容',

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -242,6 +242,29 @@ function testContentLengthCondition() {
   }
 }
 
+function testSetSelectorContent() {
+  const sample = '設定（#foo）為 "嗨呀!"';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('document.querySelector("#foo").textContent = "嗨呀!";'),
+    '設定（#foo）為 內容 should set text using helper'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testLogStatement() {
   const sample = '說一句話（"這是測試"）';
   const originalDemo = fs.readFileSync('demo.blang', 'utf8');
@@ -456,6 +479,7 @@ try {
   testToggleColorParsing();
   testMultipleToggleColor();
   testShowImageParsing();
+  testSetSelectorContent();
   testLogStatement();
   testPlayVideoParsing();
   testPauseAudioParsing();


### PR DESCRIPTION
## Summary
- use `handleFunctionCall` helper in custom pattern file
- add pattern `設定（$選擇器）為 $內容`
- test the new pattern in the test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffdc017ec83278b75e8d633a1e6d8