### PR TITLE
Fallback to syntax API in parser

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -1,5 +1,6 @@
 // 🧠 Blang parser v0.9.4 - 自動補宣告 + 條件語句語意優化整合版
 const fs = require('fs');
+const { runBlangParser } = require('./blangSyntaxAPI.js');
 const {
   processDisplayArgument,
   handleFunctionCall,
@@ -591,7 +592,12 @@ for (let i = 0; i < lines.length; i++) {
     }
   }
 
-  output.push(' '.repeat(indent) + `// 未翻譯：${line}（無匹配的語法規則）`);
+  const parsed = runBlangParser([line]).trim();
+  if (!parsed.startsWith('// 無法辨識語句')) {
+    output.push(' '.repeat(indent) + parsed);
+  } else {
+    output.push(' '.repeat(indent) + `// 未翻譯：${line}（無匹配的語法規則）`);
+  }
 }
 
 closeBlocks(0, 0);

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -423,6 +423,29 @@ function testDisplayHourMinute() {
   }
 }
 
+function testDisplayDate() {
+  const sample = '顯示今天日期';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('toLocaleDateString'),
+    '顯示今天日期 should produce alert with local date string'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testIfElsePattern() {
   const { runBlangParser } = require('../blangSyntaxAPI.js');
   const lines = ['若 (1 > 0) 則 顯示 ("yes") 否則 顯示 ("no")'];
@@ -487,6 +510,7 @@ try {
   testWaitSecondsDisplay();
   testDisplayWeekday();
   testDisplayHourMinute();
+  testDisplayDate();
   testIfElsePattern();
   testIfElsePatternChinese();
   testGetRegisteredPatterns();


### PR DESCRIPTION
## Summary
- import `runBlangParser` in `parser_v0.9.4.js`
- fallback to the syntax API when a line is unrecognised
- add test to ensure phrases like `顯示今天日期` are parsed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685001d6d1988327ac914a2c9efbca5d