### PR TITLE
Add tests for cookie and absolute value outputs

### DIFF
--- a/customBlangPatterns.js
+++ b/customBlangPatterns.js
@@ -7,10 +7,6 @@ module.exports = function registerPatterns(definePattern) {
     (物件) => `alert(JSON.stringify(${物件}, null, 2));`,
     { type: 'data', description: 'display object as JSON' }
   );
-  definePattern('顯示 $內容', (內容) => `alert(${內容});`, {
-    description: '彈出警示框顯示指定內容',
-    hints: ['內容']
-  });
 
   // 💬 變數設定
   // 將 cookie 設定語法放在一般變數設定之前，
@@ -242,4 +238,8 @@ module.exports = function registerPatterns(definePattern) {
     (網址) => `window.open(${網址}, '_blank');`,
     { type: 'control', description: 'open new window' }
   );
+  definePattern('顯示 $內容', (內容) => `alert(${內容});`, {
+    description: '彈出警示框顯示指定內容',
+    hints: ['內容']
+  });
 };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -334,6 +334,52 @@ function testCookieSetting() {
   }
 }
 
+function testDisplayAbsoluteValue() {
+  const sample = '顯示 數量 的絕對值';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('alert(Math.abs(數量));'),
+    '顯示 數量 的絕對值 應轉譯為 Math.abs'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
+function testDisplayCookieValue() {
+  const sample = '顯示 cookie token 的值';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes("alert(document.cookie.split('; ').find(c => c.startsWith(token + '='))?.split('=')[1]);"),
+    '顯示 cookie token 的值 應取得 cookie 並 alert'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testLogStatement() {
   const sample = '說一句話（"這是測試"）';
   const originalDemo = fs.readFileSync('demo.blang', 'utf8');
@@ -575,6 +621,8 @@ try {
   testFadeAnimationParsing();
   testSetSelectorContent();
   testCookieSetting();
+  testDisplayAbsoluteValue();
+  testDisplayCookieValue();
   testLogStatement();
   testPlayVideoParsing();
   testPauseAudioParsing();


### PR DESCRIPTION
## Summary
- verify parsing of absolute value expression
- test cookie retrieval parsing
- register general "顯示" pattern after more specific patterns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851533c89848327b3dac1acea7c321b