### PR TITLE
Add browser-friendly parseBlang

### DIFF
--- a/blangSyntaxAPI.js
+++ b/blangSyntaxAPI.js
@@ -111,3 +111,7 @@ module.exports = {
   getRegisteredPatterns,
   getPatternsByType
 };
+
+if (typeof window !== 'undefined') {
+  window.runBlangParser = runBlangParser;
+}

--- a/index.html
+++ b/index.html
@@ -73,17 +73,18 @@
     <!-- 模組載入順序建議：先載 array，再載核心邏輯 -->
     <script src="blang-modules/array.js"></script>
     <script src="errorHelper.js"></script>
-    <script src="output.js"></script>
-    <script src="parser.js"></script>
-    <script src="semanticHandler.js"></script>
+    <script src="blangSyntaxAPI.js"></script>
+    <script src="semanticHandler-v0.9.4.js"></script>
+    <script src="parser_v0.9.4.js"></script>
 
     <script>
+      console.log(parseBlang('顯示("你好")'));
       document.getElementById('submit').addEventListener('click', () => {
         const input = document.getElementById('input').value;
         document.getElementById('原始語句區').innerText = input;
 
         try {
-          const jsCode = parseBlang(input); // 假設 parser.js 有定義 parseBlang
+          const jsCode = parseBlang(input); // 由 parser_v0.9.4.js 提供
           document.getElementById('轉譯結果區').innerText = jsCode;
 
           const result = handleSyntax(jsCode); // 假設 semanticHandler 處理結果

--- a/semanticHandler-v0.9.4.js
+++ b/semanticHandler-v0.9.4.js
@@ -274,5 +274,12 @@ module.exports = {
   handleFunctionCall,
   styleModule
 };
+
+if (typeof window !== 'undefined') {
+  window.processDisplayArgument = processDisplayArgument;
+  window.handleFunctionCall = handleFunctionCall;
+  window.normalizeParentheses = normalizeParentheses;
+  window.processConditionExpression = processConditionExpression;
+}
 // 這個模組的功能是將中文語句轉換為 JavaScript 語句，
 // 並且支援物件屬性和中文樣式屬性轉換。


### PR DESCRIPTION
## Summary
- expose `parseBlang` that translates Chinese statements
- detect runtime to only read/write files on Node
- export helpers to `window` for browser usage
- load the new scripts in `index.html` and log a demo call

## Testing
- `npm test`
- `node parser_v0.9.4.js`
- `node -e "const {parseBlang}=require('./parser_v0.9.4.js');console.log(parseBlang('顯示(\"你好\")'));"`


------
https://chatgpt.com/codex/tasks/task_e_68516a97e4648327a981580b7e028261