### PR TITLE
Browser-ready bundles for front-end use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 output.js
 grammar_auto.md
 # Common temporary build directories
+# build output directories
 build/
-dist/
 # Node modules
 node_modules/
 # Logs

--- a/dist/blangSyntaxAPI.browser.js
+++ b/dist/blangSyntaxAPI.browser.js
@@ -1,0 +1,937 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.blangSyntaxAPI = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+module.exports = {
+  加入項目: (list, item) => `ArrayModule.加入項目(${list}, ${item})`
+};
+
+},{}],2:[function(require,module,exports){
+// blangSyntaxAPI.js
+
+const registerPatterns = require('./customBlangPatterns.js');
+const patternRegistry = [];
+const patternGroups = {};
+
+function definePattern(pattern, generator, options = {}) {
+  const entry = { pattern, generator };
+  if (options.description) entry.description = options.description;
+  if (Array.isArray(options.hints)) entry.hints = options.hints;
+  if (options.type) entry.type = options.type;
+  patternRegistry.push(entry);
+  if (entry.type) {
+    if (!patternGroups[entry.type]) {
+      patternGroups[entry.type] = [];
+    }
+    patternGroups[entry.type].push(entry);
+  }
+}
+
+// 在解析器初始化前註冊自訂語法模式
+registerPatterns(definePattern);
+
+function runBlangParser(lines) {
+  const output = [];
+  const controlStack = [];
+
+  for (let line of lines) {
+    let matched = false;
+
+    for (let { pattern, generator } of patternRegistry) {
+      const { regex, vars } = buildRegexFromPattern(pattern);
+      const match = line.match(regex);
+
+      if (match) {
+        const args = match.slice(1); // 因為 match[0] 是整串
+        const named = {};
+        vars.forEach((v, i) => {
+          named[v] = args[i];
+        });
+        output.push(generator(...args, named));
+        matched = true;
+        break;
+      }
+    }
+
+    if (!matched) {
+      // 嘗試使用舊版條件判斷處理語句
+      const legacy = legacyParse(line);
+      output.push(legacy);
+      if (legacy.trim().startsWith('}') && controlStack.length > 0) {
+        controlStack.pop();
+      }
+    }
+  }
+
+  while (controlStack.length > 0) {
+    output.push(controlStack.pop());
+  }
+
+  return output.join('\n');
+}
+
+// 舊版解析邏輯，作為沒有匹配時的備援
+function legacyParse(line) {
+  const displayMatch = line.match(/^顯示[（(](.*)[)）]$/);
+  if (displayMatch) {
+    return `alert(${displayMatch[1]});`;
+  }
+  const assignMatch = line.match(/^設定\s*(\S+)\s*為\s*(.+)$/);
+  if (assignMatch) {
+    return `let ${assignMatch[1]} = ${assignMatch[2]};`;
+  }
+  return '// 無法辨識語句：' + line;
+}
+
+function buildRegexFromPattern(pattern) {
+  // 將包含 $參數 的樣式自動轉為正則並支援括號
+  const parts = pattern.split(/(\$[\w\u4e00-\u9fa5_]+)/);
+  const vars = [];
+  let regexStr = '^';
+  for (let part of parts) {
+    if (part.startsWith('$')) {
+      vars.push(part.slice(1));
+      regexStr += '(?:\\(|（)?(.+?)(?:\\)|）)?';
+    } else if (part) {
+      regexStr += part.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
+  }
+  regexStr += '$';
+  return { regex: new RegExp(regexStr), vars };
+}
+
+function getRegisteredPatterns() {
+  return patternRegistry.map(({ pattern, type, description, hints }) => ({
+    pattern,
+    type,
+    description,
+    hints,
+  }));
+}
+
+function getPatternsByType(type) {
+  return patternGroups[type] || [];
+}
+
+module.exports = {
+  definePattern,
+  runBlangParser,
+  buildRegexFromPattern,
+  getRegisteredPatterns,
+  getPatternsByType
+};
+
+if (typeof window !== 'undefined') {
+  window.runBlangParser = runBlangParser;
+}
+
+},{"./customBlangPatterns.js":4}],3:[function(require,module,exports){
+module.exports = {
+  紅色: 'red',
+  藍色: 'blue',
+  綠色: 'green',
+  黑色: 'black',
+  白色: 'white',
+  黃色: 'yellow',
+  粉紅色: 'pink',
+  橘色: 'orange',
+  淡藍色: 'lightblue'
+};
+
+},{}],4:[function(require,module,exports){
+const { handleFunctionCall, processDisplayArgument } = require('./semanticHandler-v0.9.4.js');
+module.exports = function registerPatterns(definePattern) {
+  let toggleId = 0;
+  // 💬 基本輸出語法
+  definePattern(
+    '顯示 JSON 格式化 $物件',
+    (物件) => `alert(JSON.stringify(${物件}, null, 2));`,
+    { type: 'data', description: 'display object as JSON' }
+  );
+
+  // 💬 變數設定
+  // 將 cookie 設定語法放在一般變數設定之前，
+  // 以免被較寬鬆的模式攔截
+  definePattern(
+    '設定 cookie $名稱 為 $值',
+    (名稱, 值) => `document.cookie = ${名稱} + '=' + ${值};`,
+    { type: 'data', description: 'set browser cookie' }
+  );
+  definePattern(
+    '顯示 cookie $名稱 的值',
+    (名稱) =>
+      `alert(document.cookie.split('; ').find(c => c.startsWith(${名稱} + '='))?.split('=')[1]);`,
+    { type: 'data', description: 'get cookie value' }
+  );
+  definePattern('設定 $變數 為 $值', (變數, 值) => `let ${變數} = ${值};`, {
+    description: '宣告或重新賦值變數',
+    hints: ['變數', '值']
+  });
+
+  // ✅ 若～則～否則（無括號版本）
+  definePattern(
+    '若 $條件 則 顯示 $當真 否則 顯示 $當假',
+    (條件, 當真, 當假) => `if (${條件}) { alert(${當真}); } else { alert(${當假}); }`,
+    {
+      type: 'control',
+      description: '根據條件顯示不同內容',
+      hints: ['條件', '當真', '當假']
+    }
+  );
+
+  // ✅ 若（條件）則 顯示（語句1） 否則 顯示（語句2）
+  definePattern(
+    '若（$條件）則 顯示（$語句1） 否則 顯示（$語句2）',
+    (條件, 語句1, 語句2) => `if (${條件}) {\n  alert(${語句1});\n} else {\n  alert(${語句2});\n}`,
+    {
+      type: 'control',
+      description: '含括號的條件語句',
+      hints: ['條件', '語句1', '語句2']
+    }
+  );
+  definePattern(
+    '若($條件)則 顯示($語句1) 否則 顯示($語句2)',
+    (條件, 語句1, 語句2) => `if (${條件}) {\n  alert(${語句1});\n} else {\n  alert(${語句2});\n}`,
+    {
+      type: 'control',
+      description: '括號英文版的條件語句',
+      hints: ['條件', '語句1', '語句2']
+    }
+  );
+  definePattern(
+    '等待 $秒數 秒後 顯示 $訊息',
+    (秒數, 訊息) =>
+      `setTimeout(() => alert(${訊息}), ${秒數} * 1000);`,
+    {
+      type: 'control',
+      description: '延遲數秒後顯示訊息',
+      hints: ['秒數', '訊息（可選）']
+    }
+  );
+  definePattern(
+    '隱藏 $元素',
+    (元素) => `document.querySelector('${元素}').style.display = "none";`,
+    {
+      type: 'ui',
+      description: '隱藏指定元素',
+      hints: ['元素']
+    }
+  );
+  definePattern(
+    '顯示 $訊息 在 $選擇器',
+    (訊息, 選擇器) =>
+      `document.querySelector('${選擇器}').textContent = ${訊息};`,
+    { type: 'ui', description: 'update DOM text content' }
+  );
+  definePattern(
+    '播放音效($檔名)',
+    (檔名) => `new Audio(${檔名}).play();`,
+    { type: 'media', description: 'play audio file' }
+  );
+  definePattern(
+    '顯示圖片($來源 在 $選擇器)',
+    (來源, 選擇器) =>
+      `const img = document.createElement('img'); img.src = ${來源}; document.querySelector('${選擇器}').appendChild(img);`,
+    { type: 'ui', description: 'insert image element' }
+  );
+  definePattern(
+    '設定背景色($選擇器, $顏色)',
+    (選擇器, 顏色) =>
+      `document.querySelector('${選擇器}').style.backgroundColor = ${顏色};`,
+    { type: 'ui', description: 'change background color' }
+  );
+
+  definePattern(
+    '切換顏色($選擇器, $顏色1, $顏色2)',
+    (選擇器, 顏色1, 顏色2) => {
+      const elVar = `__toggleEl${toggleId++}`;
+      return `let ${elVar} = document.querySelector('${選擇器}'); ${elVar}.style.color = ${elVar}.style.color === ${顏色1} ? ${顏色2} : ${顏色1};`;
+    },
+    { type: 'ui', description: 'toggle text color' }
+  );
+  definePattern(
+    '播放影片($選擇器)',
+    (選擇器) => `document.querySelector('${選擇器}').play();`,
+    { type: 'media', description: 'play video element' }
+  );
+  definePattern(
+    '暫停音效($選擇器)',
+    (選擇器) => `document.querySelector('${選擇器}').pause();`,
+    { type: 'media', description: 'pause audio element' }
+  );
+  definePattern(
+    '顯示今天是星期幾',
+    () =>
+      'alert("今天是星期" + "日一二三四五六"[new Date().getDay()]);',
+    { type: 'control', description: 'show current weekday' }
+  );
+  definePattern(
+    '顯示現在是幾點幾分',
+    () =>
+      'alert("現在是" + new Date().getHours() + "點" + new Date().getMinutes() + "分");',
+    { type: 'control', description: 'show current time' }
+  );
+  definePattern(
+    '顯示現在時間',
+    () => 'alert(new Date().toLocaleString());',
+    { type: 'time' }
+  );
+  definePattern(
+    '等待 $毫秒 毫秒後 顯示 $訊息',
+    (毫秒, 訊息) => `setTimeout(() => alert(${訊息}), ${毫秒});`,
+    { type: 'control', description: 'delay message in ms' }
+  );
+  definePattern(
+    '顯示今天日期',
+    () => 'alert(new Date().toLocaleDateString());',
+    { type: 'time', description: 'show current date' }
+  );
+  definePattern(
+    '替換所有 $舊字 為 $新字 在 $字串',
+    (舊字, 新字, 字串) => `alert(${字串}.replaceAll(${舊字}, ${新字}));`,
+    { type: 'string', description: 'replace text and display' }
+  );
+  definePattern(
+    '切換顯示隱藏 $選擇器',
+    (選擇器) =>
+      `const el = document.querySelector('${選擇器}'); el.style.display = el.style.display === 'none' ? 'block' : 'none';`,
+    { type: 'ui', description: 'toggle element display' }
+  );
+  definePattern(
+    '增加透明度動畫到 $選擇器',
+    (選擇器) => {
+      const sel = processDisplayArgument(選擇器);
+      return `document.querySelector(${sel}).style.transition = 'opacity 0.5s';`;
+    },
+    { type: 'ui', description: 'fade animation' }
+  );
+  definePattern(
+    '顯示 $數字 的絕對值',
+    (數字) => `alert(Math.abs(${數字}));`,
+    { type: 'math', description: 'show absolute value' }
+  );
+  definePattern(
+    '遍歷 $清單 並顯示每項',
+    (清單) => `${清單}.forEach(item => alert(item));`,
+    { type: 'data', description: 'iterate list items' }
+  );
+  definePattern(
+    '加入 $項目 到 $清單',
+    (項目, 清單) => {
+      const item = processDisplayArgument(項目);
+      const list = processDisplayArgument(清單);
+      return `ArrayModule.加入項目(${list}, ${item});`;
+    },
+    { type: 'data', description: 'append item to list' }
+  );
+  definePattern(
+    '把 $項目 加進 $清單',
+    (項目, 清單) => {
+      const item = processDisplayArgument(項目);
+      const list = processDisplayArgument(清單);
+      return `ArrayModule.加入項目(${list}, ${item});`;
+    },
+    { type: 'data', description: 'append item to list' }
+  );
+  definePattern(
+    '停止所有音效',
+    () => "document.querySelectorAll('audio').forEach(a => a.pause());",
+    { type: 'media', description: 'pause all audio' }
+  );
+  definePattern(
+    '顯示目前瀏覽器語系',
+    () => 'alert(navigator.language);',
+    { type: 'data', description: 'show browser language' }
+  );
+  definePattern(
+    '新增元素 $標籤 到 $選擇器',
+    (標籤, 選擇器) => {
+      const tag = processDisplayArgument(標籤);
+      const sel = processDisplayArgument(選擇器);
+      return `document.querySelector(${sel}).appendChild(document.createElement(${tag}));`;
+    },
+    { type: 'ui', description: 'append new element' }
+  );
+  definePattern(
+    '清空 $選擇器 的內容',
+    (選擇器) => `document.querySelector('${選擇器}').innerHTML = '';`,
+    { type: 'ui', description: 'clear element content' }
+  );
+  definePattern(
+    '設定文字於 $選擇器 為 $文字',
+    (選擇器, 文字) => `document.querySelector('${選擇器}').textContent = ${文字};`,
+    { type: 'ui', description: 'set text content' }
+  );
+  definePattern(
+    '設定（$選擇器）為 $內容',
+    (選擇器, 內容) => handleFunctionCall('設定文字內容', `${選擇器}, ${內容}`),
+    { type: 'ui' }
+  );
+  definePattern(
+    '在控制台輸出 $內容',
+    (內容) => `console.log(${內容});`,
+    { type: 'log', description: 'console output' }
+  );
+  definePattern(
+    '顯示隨機整數至 $最大值',
+    (最大值) => `alert(Math.floor(Math.random() * ${最大值}));`,
+    { type: 'math', description: 'random integer' }
+  );
+  definePattern(
+    '反轉 $清單',
+    (清單) => `${清單}.reverse();`,
+    { type: 'data', description: 'reverse list' }
+  );
+  definePattern(
+    '顯示網址參數 $鍵',
+    (鍵) => `alert(new URLSearchParams(location.search).get(${鍵}));`,
+    { type: 'data', description: 'show query parameter' }
+  );
+  definePattern(
+    '循環播放音樂 $檔名',
+    (檔名) => `const a = new Audio(${檔名}); a.loop = true; a.play();`,
+    { type: 'media', description: 'loop audio' }
+  );
+  definePattern(
+    '開新視窗到 $網址',
+    (網址) => `window.open(${網址}, '_blank');`,
+    { type: 'control', description: 'open new window' }
+  );
+  definePattern('顯示 $內容', (內容) => `alert(${內容});`, {
+    description: '彈出警示框顯示指定內容',
+    hints: ['內容']
+  });
+};
+},{"./semanticHandler-v0.9.4.js":12}],5:[function(require,module,exports){
+module.exports = {
+  顯示訊息框: (msg) => `alert(${msg})`
+};
+
+},{}],6:[function(require,module,exports){
+module.exports = {
+  顯示圖片: (src, selector) => {
+    const cleanSrc = src.replace(/^["']|["']$/g, '');
+    return `const img = document.createElement('img'); img.src = "${cleanSrc}"; document.querySelector(${selector}).appendChild(img)`;
+  }
+};
+
+},{}],7:[function(require,module,exports){
+// inputModule.js
+module.exports = {
+  使用者輸入: (問題) => `prompt(${問題})`
+};
+
+},{}],8:[function(require,module,exports){
+module.exports = {
+  說一句話: (text) => {
+    const clean = /^['"].*['"]$/.test(text.trim()) ? text : `"${text}"`;
+    return `console.log(${clean})`;
+  }
+};
+
+},{}],9:[function(require,module,exports){
+// mathModule.js
+module.exports = {
+  隨機一個數: (max) => `Math.floor(Math.random() * ${max})`,
+  四捨五入: (value) => `Math.round(${value})`,
+  無條件捨去: (value) => `Math.floor(${value})`,
+  無條件進位: (value) => `Math.ceil(${value})`,
+  平方: (value) => `Math.pow(${value}, 2)`,
+  次方: (base, exp) => `Math.pow(${base}, ${exp})`,
+  絕對值: (value) => `Math.abs(${value})`
+};
+
+},{}],10:[function(require,module,exports){
+module.exports = {
+  播放影片: (target) => `document.querySelector(${target}).play()`,
+  暫停音效: (target) => `document.querySelector(${target}).pause()`
+};
+
+},{}],11:[function(require,module,exports){
+// objectModule.js
+
+module.exports = {
+  建立人物: (名字, 年齡) => `let 人物 = { 名字: ${名字}, 年齡: ${年齡} }`,
+  取得屬性: (obj, key) => `${obj}[${key}]`
+};
+
+},{}],12:[function(require,module,exports){
+// v0.9.7 - semanticHandler.js（支援物件屬性 + 中文樣式屬性轉換）
+
+const stringModule = require('./stringModule.js');
+const mathModule = require('./mathModule.js');
+const objectModule = require('./objectModule.js');
+const dialogModule = require('./dialogModule.js');
+const inputModule = require('./inputModule.js');
+const styleModule = require('./styleModule.js');
+const imageModule = require('./imageModule.js');
+const logModule = require('./logModule.js');
+const mediaModule = require('./mediaModule.js');
+const soundModule = require('./soundModule.js');
+const timeModule = require('./timeModule.js');
+const textModule = require('./textModule.js');
+const arrayModule = require('./arrayModule.js');
+const vocabularyMap = require('./vocabulary_map.json');
+const colorMap = require('./colorMap.js');
+
+const modules = {
+  stringModule,
+  mathModule,
+  objectModule,
+  dialogModule,
+  inputModule,
+  styleModule,
+  imageModule,
+  logModule,
+  mediaModule,
+  soundModule,
+  timeModule,
+  textModule,
+  arrayModule
+};
+/***** 中文函式 → FQN 對應 *****/
+const FUNC_MAP = {
+  加入項目: 'ArrayModule.加入項目',
+  加入清單項目: 'ArrayModule.加入項目',
+  移除最後: 'ArrayModule.移除最後',
+  顯示全部: 'ArrayModule.顯示全部',
+  顯示第幾項: 'ArrayModule.顯示第幾項',
+  'AI 回覆': 'DialogModule.AI回覆',
+  顯示訊息框: 'DialogModule.顯示訊息框',
+  播放音效: 'soundModule.播放音效',
+  設定樣式: 'StyleModule.設定樣式'
+};
+
+// ✅ 括號、引號、問號的統一處理（全形→半形）
+function normalizeParentheses(text) {
+  return text
+    .replace(/[（]/g, '(') // 全形左括號
+    .replace(/[）]/g, ')') // 全形右括號
+    .replace(/[『「]/g, '"') // 中文左引號
+    .replace(/[」』]/g, '"') // 中文右引號
+    .replace(/[？]/g, '?') // 中文問號
+    .replace(/，/g, ','); // 中文逗號，部分情境要支援
+}
+
+// ✅ 字串模板套用（$1, $2 ...）自動帶入參數
+function applyTemplate(template, args) {
+  return args.reduce(
+    (acc, val, i) => acc.replace(new RegExp(`\\$${i + 1}`, 'g'), val.trim()),
+    template
+  );
+}
+
+// ✅ 拆解「函式名（參數, 參數2）」的括號內參數
+function extractArguments(text, phrase = '') {
+  // 先去掉 phrase，以防 phrase 也有括號
+  let core = text;
+  if (phrase && text.startsWith(phrase)) {
+    core = text.slice(phrase.length);
+  }
+  const argsMatch = core.match(/[（(](.*)[）)]/);
+  // split 逗號時兩側容忍空白
+  return argsMatch ? argsMatch[1].split(/\s*,\s*/) : [];
+}
+
+// ✅ 條件式中文自動轉成 JS 運算子（內含強化）
+function processConditionExpression(str) {
+  if (!str) return str;
+  return str
+    .replace(/（/g, '(')
+    .replace(/）/g, ')')
+    .replace(/。/g, '.') // 中文句號有時出現在成員存取
+    .replace(/內容長度/g, 'value.length')
+    .replace(/長度/g, 'length')
+    .replace(/內容/g, 'value')
+    .replace(/大於等於/g, '>=')
+    .replace(/小於等於/g, '<=')
+    .replace(/大於/g, '>')
+    .replace(/小於/g, '<')
+    .replace(/不為/g, '!==')
+    .replace(/為/g, '===') // 注意：「為」通常對應嚴格等於
+    .replace(/不等於/g, '!=')
+    .replace(/＝{2,}/g, '==') // 多個全形等號，統一成 JS
+    .replace(/＝/g, '==') // 單個全形等號也統一
+    .replace(/且/g, '&&') // 補充：有些條件會寫「且」
+    .replace(/或/g, '||'); // 補充：有些條件會寫「或」
+}
+
+function processDisplayArgument(arg, declaredVars = new Set()) {
+  const trimmed = arg.trim();
+  if (/^"[A-Za-z_]+Module\.[^"]+"$/.test(trimmed)) {
+    return trimmed.slice(1, -1);
+  }
+
+  if (!trimmed) return '""';
+
+  arg = normalizeParentheses(trimmed);
+
+  // ArrayModule特殊處理
+  if (/^顯示第幾項[（(](.*?),(.*)[）)]$/.test(arg)) {
+    const m = arg.match(/^顯示第幾項[（(](.*?),(.*)[）)]$/);
+    return `ArrayModule.顯示第幾項(${m[1].trim()}, ${m[2].trim()})`;
+  }
+  if (/^顯示全部[（(](.*)[）)]$/.test(arg)) {
+    const m = arg.match(/^顯示全部[（(](.*)[）)]$/);
+    return `ArrayModule.顯示全部(${m[1].trim()})`;
+  }
+
+  // 直接識別 ModuleName.函式名()
+  if (/^[A-Za-z_]+Module\.[\u4e00-\u9fa5\w]+\(.*\)$/.test(arg)) {
+    return arg;
+  }
+
+  // 物件屬性處理
+  if (/^[\u4e00-\u9fa5\w]+\[\s*[\u4e00-\u9fa5a-zA-Z_][\w\u4e00-\u9fa5]*\s*\]$/.test(arg)) {
+    const match = arg.match(
+      /([\u4e00-\u9fa5\w]+)\[\s*([\u4e00-\u9fa5a-zA-Z_][\w\u4e00-\u9fa5]*)\s*\]/
+    );
+    if (match) {
+      const obj = match[1];
+      const key = match[2];
+      if (declaredVars.has(key)) {
+        return `${obj}[${key}]`; // ✅ 是變數，直接留
+      } else {
+        return `${obj}["${key}"]`; // ⚠️ 不是變數，補上引號
+      }
+      return declaredVars.has(key) ? `${obj}[${key}]` : `${obj}["${key}"]`;
+    }
+  }
+
+  // 處理 ["key"]
+  if (/^[\u4e00-\u9fa5\w]+\s*\[\s*["“”‘’'][^"'“”‘’]+["“”‘’']\s*\]$/.test(arg)) {
+    return arg.replace(/[“”‘’]/g, '"').replace(/[‘’]/g, "'");
+  }
+
+  // 數字型key直接返回
+  if (/^[\u4e00-\u9fa5\w]+\[\s*\d+\s*\]$/.test(arg)) {
+    return arg;
+  }
+
+  if (arg.endsWith('.內容')) return arg.replace('.內容', '.value');
+  if (declaredVars.has(arg)) return arg;
+
+  // 🔥【正確位置】先判斷顏色轉換（重要！）
+  if (colorMap[arg]) {
+    return `"${colorMap[arg]}"`;
+  }
+
+  // 最後才進行純單詞包引號處理
+  if (/^[\u4e00-\u9fa5a-zA-Z_][\w\u4e00-\u9fa5]*$/.test(arg)) {
+    return `"${arg}"`;
+  }
+
+  for (const phrase in vocabularyMap) {
+    if (arg.startsWith(phrase + '（') || arg.startsWith(phrase + '(')) {
+      const def = vocabularyMap[phrase];
+      const moduleName = def.module;
+      const jsTemplate = def.js;
+      const args = extractArguments(arg, phrase);
+      if (!args) break;
+      const cleanArgs = args.map((p) => {
+        const trimmed = p.trim();
+        const raw = trimmed.replace(/^\s*["“”'']|["“”'']\s*$/g, '');
+
+        if (phrase === '替換文字' && /^['"“”].*['"“”]$/.test(trimmed)) {
+          return `"${raw}"`;
+        }
+
+        if (colorMap[raw]) {
+          return `"${colorMap[raw]}"`;
+        }
+        if (/^[\d.]+$/.test(raw)) return raw;
+        if (/^[a-zA-Z_\u4e00-\u9fa5][\w\u4e00-\u9fa5]*$/.test(raw) || declaredVars.has(raw))
+          return raw;
+        return `"${raw}"`;
+      });
+      const mod = modules[moduleName];
+      if (mod && typeof mod[phrase] === 'function') {
+        try {
+          return mod[phrase](...cleanArgs);
+        } catch (e) {
+          console.warn(`⚠️ 模組錯誤：${moduleName}.${phrase} 呼叫失敗`, e);
+        }
+      }
+      return applyTemplate(jsTemplate, cleanArgs);
+    }
+  }
+
+  if (/^".*"$/.test(arg)) return arg;
+  return `"${arg.replace(/^"+|"+$/g, '')}"`;
+}
+
+function handleFunctionCall(funcName, params, indent = 0, declaredVars = new Set()) {
+  const space = ' '.repeat(indent);
+  const fqName = FUNC_MAP[funcName] || funcName;
+
+
+  if (funcName === 'AI 回覆' || funcName === '呼叫 AI 回覆') {
+    return `${space}呼叫AI回覆(${processDisplayArgument(params, declaredVars)}); // 🔮 AI`;
+  }
+
+  if (vocabularyMap[funcName]) {
+    const def = vocabularyMap[funcName];
+    const moduleName = def.module;
+    const jsTemplate = def.js;
+
+    const args = params.split(',').map((p, idx) => {
+      const raw = p.trim().replace(/^\s*["“”‘’']|["“”‘’']\s*$/g, '');
+
+      // 🔥 特別處理「設定樣式」的第三個參數（顏色）
+      if (funcName === '設定樣式' && idx === 2 && colorMap[raw]) {
+        return `"${colorMap[raw]}"`;
+      }
+      if (funcName === '設定背景色' && idx === 1 && colorMap[raw]) {
+        return `"${colorMap[raw]}"`;
+      }
+
+      // 支援物件屬性 ["key"]
+      if (/^[\u4e00-\u9fa5\w]+\s*\[\s*["“”‘’'][^"'“”‘’]+["“”‘’']\s*\]$/.test(raw)) {
+        return raw.replace(/[“”‘’]/g, '"');
+      }
+
+      // 建立人物的第一參數補上雙引號
+      if (funcName === '建立人物' && idx === 0) {
+        return `"${raw}"`;
+      }
+
+      // 數字
+      if (/^[\d.]+$/.test(raw)) return raw;
+
+      // 合法變數
+      if (/^[a-zA-Z_\u4e00-\u9fa5][\w\u4e00-\u9fa5]*$/.test(raw) || declaredVars.has(raw)) {
+        return raw;
+      }
+
+      if (/^\d+(\.\d+)?(px|em|rem|%)$/.test(raw)) return `"${raw}"`;
+
+      // 其他全部包雙引號
+      return `"${raw}"`;
+    });
+
+    const mod = modules[moduleName];
+    if (mod && typeof mod[funcName] === 'function') {
+      try {
+        return `${space}${mod[funcName](...args)};`;
+      } catch (e) {
+        console.warn(`⚠️ 模組 ${moduleName}.${funcName} 錯誤`, e);
+      }
+    }
+    return `${space}${applyTemplate(jsTemplate, args)};`;
+  }
+
+  return `${space}${fqName}(${params});`;
+}
+
+module.exports = {
+  normalizeParentheses,
+  applyTemplate,
+  extractArguments,
+  processDisplayArgument,
+  processConditionExpression,
+  handleFunctionCall,
+  styleModule
+};
+
+if (typeof window !== 'undefined') {
+  window.processDisplayArgument = processDisplayArgument;
+  window.handleFunctionCall = handleFunctionCall;
+  window.normalizeParentheses = normalizeParentheses;
+  window.processConditionExpression = processConditionExpression;
+}
+// 這個模組的功能是將中文語句轉換為 JavaScript 語句，
+// 並且支援物件屬性和中文樣式屬性轉換。
+
+},{"./arrayModule.js":1,"./colorMap.js":3,"./dialogModule.js":5,"./imageModule.js":6,"./inputModule.js":7,"./logModule.js":8,"./mathModule.js":9,"./mediaModule.js":10,"./objectModule.js":11,"./soundModule.js":13,"./stringModule.js":14,"./styleModule.js":15,"./textModule.js":16,"./timeModule.js":17,"./vocabulary_map.json":18}],13:[function(require,module,exports){
+module.exports = {
+  播放音效: (src) => `new Audio(${src}).play()`
+};
+
+},{}],14:[function(require,module,exports){
+// stringModule.js
+module.exports = {
+  轉大寫: (input) => `${input}.toUpperCase()`,
+  包含: (str, substr) => `${str}.includes(${substr})`,
+  長度: (input) => `${input}.length`
+};
+
+},{}],15:[function(require,module,exports){
+module.exports = {
+  設定樣式: (selector, styleProp, value) => {
+    const propMap = {
+      背景色: 'backgroundColor',
+      文字顏色: 'color',
+      字型大小: 'fontSize',
+      邊框: 'border',
+      寬度: 'width',
+      高度: 'height'
+    };
+
+    const cleanProp = propMap[styleProp.replace(/['"]/g, '')] || styleProp.replace(/['"]/g, '');
+    const cleanValue = value.replace(/^["']|["']$/g, ''); // 🔥 去掉 value 最外層引號
+
+    return `document.querySelector(${selector}).style["${cleanProp}"] = "${cleanValue}"`;
+  },
+  隱藏元素: (selector) => {
+    return `document.querySelector(${selector}).style.display = "none"`;
+  },
+  隱藏: (selector) => {
+    return `document.querySelector(${selector}).style.display = "none"`;
+  },
+  顯示: (selector) => {
+    return `document.querySelector(${selector}).style.display = "block"`;
+  },
+  設定背景色: (selector, color) => {
+    const cleanColor = color.replace(/^['"]|['"]$/g, '');
+    return `document.querySelector(${selector}).style.backgroundColor = "${cleanColor}"`;
+  }
+};
+
+},{}],16:[function(require,module,exports){
+module.exports = {
+  設定文字內容: (selector, text) => {
+    return `document.querySelector(${selector}).textContent = ${text}`;
+  }
+};
+
+},{}],17:[function(require,module,exports){
+module.exports = {
+  獲取現在時間: () => 'new Date().toLocaleTimeString()',
+  顯示現在時間: () => 'alert(new Date().toLocaleString())',
+  顯示今天是星期幾: () =>
+    'alert("今天是星期" + "日一二三四五六"[new Date().getDay()])',
+  顯示現在是幾點幾分: () =>
+    'alert("現在是" + new Date().getHours() + "點" + new Date().getMinutes() + "分")'
+};
+
+},{}],18:[function(require,module,exports){
+module.exports={
+    "轉大寫": {
+        "module": "stringModule",
+        "js": "$1.toUpperCase()"
+    },
+    "包含": {
+        "module": "stringModule",
+        "js": "$1.includes($2)"
+    },
+    "隨機一個數": {
+        "module": "mathModule",
+        "js": "Math.floor(Math.random() * $1)"
+    },
+    "四捨五入": {
+        "module": "mathModule",
+        "js": "Math.round($1)"
+    },
+    "平方": {
+        "module": "mathModule",
+        "js": "Math.pow($1, 2)"
+    },
+    "建立人物": {
+        "module": "objectModule",
+        "js": "let 人物 = { 名字: \"$1\", 年齡: $2 }"
+    },
+    "取得屬性": {
+        "module": "objectModule",
+        "js": "$1[$2]"
+    },
+    "顯示訊息框": {
+        "module": "dialogModule",
+        "js": "alert($1)"
+    },
+    "使用者輸入": {
+        "module": "inputModule",
+        "js": "prompt($1)"
+    },
+    "設定樣式": {
+        "module": "styleModule",
+        "js": "styleModule.設定樣式($1, $2, $3)"
+    },
+    "設定背景色": {
+        "module": "styleModule",
+        "js": "styleModule.設定背景色($1, $2)"
+    },
+    "建立物件": {
+        "module": "objectModule",
+        "js": "ObjectModule.建立物件($1, $2, $3, $4)"
+    },
+    "顯示清單長度": {
+        "module": "arrayModule",
+        "js": "$1.length"
+    },
+    "清空清單": {
+        "module": "arrayModule",
+        "js": "$1.length = 0"
+    },
+    "判斷是否為空": {
+        "module": "arrayModule",
+        "js": "$1.length === 0"
+    },
+    "切換顏色": {
+        "module": "styleModule",
+        "js": "$1.style.backgroundColor = ($1.style.backgroundColor === '$2' ? '$3' : '$2')"
+    },
+    "隱藏元素": {
+        "module": "styleModule",
+        "js": "styleModule.隱藏元素($1)"
+    },
+    "隱藏": {
+        "module": "styleModule",
+        "js": "styleModule.隱藏($1)"
+    },
+    "顯示": {
+        "module": "styleModule",
+        "js": "styleModule.顯示($1)"
+    },
+    "切換顯示隱藏": {
+        "module": "styleModule",
+        "js": "const el = document.querySelector($1); el.style.display = el.style.display === 'none' ? 'block' : 'none'"
+    },
+    "播放影片": {
+        "module": "mediaModule",
+        "js": "$1.play()"
+    },
+    "暫停音效": {
+        "module": "mediaModule",
+        "js": "$1.pause()"
+    },
+    "獲取現在時間": {
+        "module": "timeModule",
+        "js": "new Date().toLocaleTimeString()"
+    },
+    "顯示現在時間": {
+        "module": "timeModule",
+        "js": "alert(new Date().toLocaleString())"
+    },
+    "顯示今天是星期幾": {
+        "module": "timeModule",
+        "js": "alert(\"今天是星期\" + \"日一二三四五六\"[new Date().getDay()])"
+    },
+    "顯示現在是幾點幾分": {
+        "module": "timeModule",
+        "js": "alert(\"現在是\" + new Date().getHours() + \"點\" + new Date().getMinutes() + \"分\")"
+    },
+    "替換文字": {
+        "module": "stringModule",
+        "js": "$1.replace($2, $3)"
+    },
+    "轉跳網頁": {
+        "module": "core",
+        "js": "window.location.href = $1"
+    },
+    "顯示圖片": {
+        "module": "imageModule",
+        "js": "imageModule.顯示圖片($1, $2)"
+    },
+    "播放音效": {
+        "module": "soundModule",
+        "js": "new Audio($1).play()"
+    },
+    "設定文字內容": {
+        "module": "textModule",
+        "js": "textModule.設定文字內容($1, $2)"
+    },
+    "說一句話": {
+        "module": "logModule",
+        "js": "logModule.說一句話($1)"
+    }
+}
+
+},{}]},{},[2])(2)
+});

--- a/dist/semanticHandler-v0.9.4.browser.js
+++ b/dist/semanticHandler-v0.9.4.browser.js
@@ -1,0 +1,554 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.semanticHandler = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+module.exports = {
+  加入項目: (list, item) => `ArrayModule.加入項目(${list}, ${item})`
+};
+
+},{}],2:[function(require,module,exports){
+module.exports = {
+  紅色: 'red',
+  藍色: 'blue',
+  綠色: 'green',
+  黑色: 'black',
+  白色: 'white',
+  黃色: 'yellow',
+  粉紅色: 'pink',
+  橘色: 'orange',
+  淡藍色: 'lightblue'
+};
+
+},{}],3:[function(require,module,exports){
+module.exports = {
+  顯示訊息框: (msg) => `alert(${msg})`
+};
+
+},{}],4:[function(require,module,exports){
+module.exports = {
+  顯示圖片: (src, selector) => {
+    const cleanSrc = src.replace(/^["']|["']$/g, '');
+    return `const img = document.createElement('img'); img.src = "${cleanSrc}"; document.querySelector(${selector}).appendChild(img)`;
+  }
+};
+
+},{}],5:[function(require,module,exports){
+// inputModule.js
+module.exports = {
+  使用者輸入: (問題) => `prompt(${問題})`
+};
+
+},{}],6:[function(require,module,exports){
+module.exports = {
+  說一句話: (text) => {
+    const clean = /^['"].*['"]$/.test(text.trim()) ? text : `"${text}"`;
+    return `console.log(${clean})`;
+  }
+};
+
+},{}],7:[function(require,module,exports){
+// mathModule.js
+module.exports = {
+  隨機一個數: (max) => `Math.floor(Math.random() * ${max})`,
+  四捨五入: (value) => `Math.round(${value})`,
+  無條件捨去: (value) => `Math.floor(${value})`,
+  無條件進位: (value) => `Math.ceil(${value})`,
+  平方: (value) => `Math.pow(${value}, 2)`,
+  次方: (base, exp) => `Math.pow(${base}, ${exp})`,
+  絕對值: (value) => `Math.abs(${value})`
+};
+
+},{}],8:[function(require,module,exports){
+module.exports = {
+  播放影片: (target) => `document.querySelector(${target}).play()`,
+  暫停音效: (target) => `document.querySelector(${target}).pause()`
+};
+
+},{}],9:[function(require,module,exports){
+// objectModule.js
+
+module.exports = {
+  建立人物: (名字, 年齡) => `let 人物 = { 名字: ${名字}, 年齡: ${年齡} }`,
+  取得屬性: (obj, key) => `${obj}[${key}]`
+};
+
+},{}],10:[function(require,module,exports){
+// v0.9.7 - semanticHandler.js（支援物件屬性 + 中文樣式屬性轉換）
+
+const stringModule = require('./stringModule.js');
+const mathModule = require('./mathModule.js');
+const objectModule = require('./objectModule.js');
+const dialogModule = require('./dialogModule.js');
+const inputModule = require('./inputModule.js');
+const styleModule = require('./styleModule.js');
+const imageModule = require('./imageModule.js');
+const logModule = require('./logModule.js');
+const mediaModule = require('./mediaModule.js');
+const soundModule = require('./soundModule.js');
+const timeModule = require('./timeModule.js');
+const textModule = require('./textModule.js');
+const arrayModule = require('./arrayModule.js');
+const vocabularyMap = require('./vocabulary_map.json');
+const colorMap = require('./colorMap.js');
+
+const modules = {
+  stringModule,
+  mathModule,
+  objectModule,
+  dialogModule,
+  inputModule,
+  styleModule,
+  imageModule,
+  logModule,
+  mediaModule,
+  soundModule,
+  timeModule,
+  textModule,
+  arrayModule
+};
+/***** 中文函式 → FQN 對應 *****/
+const FUNC_MAP = {
+  加入項目: 'ArrayModule.加入項目',
+  加入清單項目: 'ArrayModule.加入項目',
+  移除最後: 'ArrayModule.移除最後',
+  顯示全部: 'ArrayModule.顯示全部',
+  顯示第幾項: 'ArrayModule.顯示第幾項',
+  'AI 回覆': 'DialogModule.AI回覆',
+  顯示訊息框: 'DialogModule.顯示訊息框',
+  播放音效: 'soundModule.播放音效',
+  設定樣式: 'StyleModule.設定樣式'
+};
+
+// ✅ 括號、引號、問號的統一處理（全形→半形）
+function normalizeParentheses(text) {
+  return text
+    .replace(/[（]/g, '(') // 全形左括號
+    .replace(/[）]/g, ')') // 全形右括號
+    .replace(/[『「]/g, '"') // 中文左引號
+    .replace(/[」』]/g, '"') // 中文右引號
+    .replace(/[？]/g, '?') // 中文問號
+    .replace(/，/g, ','); // 中文逗號，部分情境要支援
+}
+
+// ✅ 字串模板套用（$1, $2 ...）自動帶入參數
+function applyTemplate(template, args) {
+  return args.reduce(
+    (acc, val, i) => acc.replace(new RegExp(`\\$${i + 1}`, 'g'), val.trim()),
+    template
+  );
+}
+
+// ✅ 拆解「函式名（參數, 參數2）」的括號內參數
+function extractArguments(text, phrase = '') {
+  // 先去掉 phrase，以防 phrase 也有括號
+  let core = text;
+  if (phrase && text.startsWith(phrase)) {
+    core = text.slice(phrase.length);
+  }
+  const argsMatch = core.match(/[（(](.*)[）)]/);
+  // split 逗號時兩側容忍空白
+  return argsMatch ? argsMatch[1].split(/\s*,\s*/) : [];
+}
+
+// ✅ 條件式中文自動轉成 JS 運算子（內含強化）
+function processConditionExpression(str) {
+  if (!str) return str;
+  return str
+    .replace(/（/g, '(')
+    .replace(/）/g, ')')
+    .replace(/。/g, '.') // 中文句號有時出現在成員存取
+    .replace(/內容長度/g, 'value.length')
+    .replace(/長度/g, 'length')
+    .replace(/內容/g, 'value')
+    .replace(/大於等於/g, '>=')
+    .replace(/小於等於/g, '<=')
+    .replace(/大於/g, '>')
+    .replace(/小於/g, '<')
+    .replace(/不為/g, '!==')
+    .replace(/為/g, '===') // 注意：「為」通常對應嚴格等於
+    .replace(/不等於/g, '!=')
+    .replace(/＝{2,}/g, '==') // 多個全形等號，統一成 JS
+    .replace(/＝/g, '==') // 單個全形等號也統一
+    .replace(/且/g, '&&') // 補充：有些條件會寫「且」
+    .replace(/或/g, '||'); // 補充：有些條件會寫「或」
+}
+
+function processDisplayArgument(arg, declaredVars = new Set()) {
+  const trimmed = arg.trim();
+  if (/^"[A-Za-z_]+Module\.[^"]+"$/.test(trimmed)) {
+    return trimmed.slice(1, -1);
+  }
+
+  if (!trimmed) return '""';
+
+  arg = normalizeParentheses(trimmed);
+
+  // ArrayModule特殊處理
+  if (/^顯示第幾項[（(](.*?),(.*)[）)]$/.test(arg)) {
+    const m = arg.match(/^顯示第幾項[（(](.*?),(.*)[）)]$/);
+    return `ArrayModule.顯示第幾項(${m[1].trim()}, ${m[2].trim()})`;
+  }
+  if (/^顯示全部[（(](.*)[）)]$/.test(arg)) {
+    const m = arg.match(/^顯示全部[（(](.*)[）)]$/);
+    return `ArrayModule.顯示全部(${m[1].trim()})`;
+  }
+
+  // 直接識別 ModuleName.函式名()
+  if (/^[A-Za-z_]+Module\.[\u4e00-\u9fa5\w]+\(.*\)$/.test(arg)) {
+    return arg;
+  }
+
+  // 物件屬性處理
+  if (/^[\u4e00-\u9fa5\w]+\[\s*[\u4e00-\u9fa5a-zA-Z_][\w\u4e00-\u9fa5]*\s*\]$/.test(arg)) {
+    const match = arg.match(
+      /([\u4e00-\u9fa5\w]+)\[\s*([\u4e00-\u9fa5a-zA-Z_][\w\u4e00-\u9fa5]*)\s*\]/
+    );
+    if (match) {
+      const obj = match[1];
+      const key = match[2];
+      if (declaredVars.has(key)) {
+        return `${obj}[${key}]`; // ✅ 是變數，直接留
+      } else {
+        return `${obj}["${key}"]`; // ⚠️ 不是變數，補上引號
+      }
+      return declaredVars.has(key) ? `${obj}[${key}]` : `${obj}["${key}"]`;
+    }
+  }
+
+  // 處理 ["key"]
+  if (/^[\u4e00-\u9fa5\w]+\s*\[\s*["“”‘’'][^"'“”‘’]+["“”‘’']\s*\]$/.test(arg)) {
+    return arg.replace(/[“”‘’]/g, '"').replace(/[‘’]/g, "'");
+  }
+
+  // 數字型key直接返回
+  if (/^[\u4e00-\u9fa5\w]+\[\s*\d+\s*\]$/.test(arg)) {
+    return arg;
+  }
+
+  if (arg.endsWith('.內容')) return arg.replace('.內容', '.value');
+  if (declaredVars.has(arg)) return arg;
+
+  // 🔥【正確位置】先判斷顏色轉換（重要！）
+  if (colorMap[arg]) {
+    return `"${colorMap[arg]}"`;
+  }
+
+  // 最後才進行純單詞包引號處理
+  if (/^[\u4e00-\u9fa5a-zA-Z_][\w\u4e00-\u9fa5]*$/.test(arg)) {
+    return `"${arg}"`;
+  }
+
+  for (const phrase in vocabularyMap) {
+    if (arg.startsWith(phrase + '（') || arg.startsWith(phrase + '(')) {
+      const def = vocabularyMap[phrase];
+      const moduleName = def.module;
+      const jsTemplate = def.js;
+      const args = extractArguments(arg, phrase);
+      if (!args) break;
+      const cleanArgs = args.map((p) => {
+        const trimmed = p.trim();
+        const raw = trimmed.replace(/^\s*["“”'']|["“”'']\s*$/g, '');
+
+        if (phrase === '替換文字' && /^['"“”].*['"“”]$/.test(trimmed)) {
+          return `"${raw}"`;
+        }
+
+        if (colorMap[raw]) {
+          return `"${colorMap[raw]}"`;
+        }
+        if (/^[\d.]+$/.test(raw)) return raw;
+        if (/^[a-zA-Z_\u4e00-\u9fa5][\w\u4e00-\u9fa5]*$/.test(raw) || declaredVars.has(raw))
+          return raw;
+        return `"${raw}"`;
+      });
+      const mod = modules[moduleName];
+      if (mod && typeof mod[phrase] === 'function') {
+        try {
+          return mod[phrase](...cleanArgs);
+        } catch (e) {
+          console.warn(`⚠️ 模組錯誤：${moduleName}.${phrase} 呼叫失敗`, e);
+        }
+      }
+      return applyTemplate(jsTemplate, cleanArgs);
+    }
+  }
+
+  if (/^".*"$/.test(arg)) return arg;
+  return `"${arg.replace(/^"+|"+$/g, '')}"`;
+}
+
+function handleFunctionCall(funcName, params, indent = 0, declaredVars = new Set()) {
+  const space = ' '.repeat(indent);
+  const fqName = FUNC_MAP[funcName] || funcName;
+
+
+  if (funcName === 'AI 回覆' || funcName === '呼叫 AI 回覆') {
+    return `${space}呼叫AI回覆(${processDisplayArgument(params, declaredVars)}); // 🔮 AI`;
+  }
+
+  if (vocabularyMap[funcName]) {
+    const def = vocabularyMap[funcName];
+    const moduleName = def.module;
+    const jsTemplate = def.js;
+
+    const args = params.split(',').map((p, idx) => {
+      const raw = p.trim().replace(/^\s*["“”‘’']|["“”‘’']\s*$/g, '');
+
+      // 🔥 特別處理「設定樣式」的第三個參數（顏色）
+      if (funcName === '設定樣式' && idx === 2 && colorMap[raw]) {
+        return `"${colorMap[raw]}"`;
+      }
+      if (funcName === '設定背景色' && idx === 1 && colorMap[raw]) {
+        return `"${colorMap[raw]}"`;
+      }
+
+      // 支援物件屬性 ["key"]
+      if (/^[\u4e00-\u9fa5\w]+\s*\[\s*["“”‘’'][^"'“”‘’]+["“”‘’']\s*\]$/.test(raw)) {
+        return raw.replace(/[“”‘’]/g, '"');
+      }
+
+      // 建立人物的第一參數補上雙引號
+      if (funcName === '建立人物' && idx === 0) {
+        return `"${raw}"`;
+      }
+
+      // 數字
+      if (/^[\d.]+$/.test(raw)) return raw;
+
+      // 合法變數
+      if (/^[a-zA-Z_\u4e00-\u9fa5][\w\u4e00-\u9fa5]*$/.test(raw) || declaredVars.has(raw)) {
+        return raw;
+      }
+
+      if (/^\d+(\.\d+)?(px|em|rem|%)$/.test(raw)) return `"${raw}"`;
+
+      // 其他全部包雙引號
+      return `"${raw}"`;
+    });
+
+    const mod = modules[moduleName];
+    if (mod && typeof mod[funcName] === 'function') {
+      try {
+        return `${space}${mod[funcName](...args)};`;
+      } catch (e) {
+        console.warn(`⚠️ 模組 ${moduleName}.${funcName} 錯誤`, e);
+      }
+    }
+    return `${space}${applyTemplate(jsTemplate, args)};`;
+  }
+
+  return `${space}${fqName}(${params});`;
+}
+
+module.exports = {
+  normalizeParentheses,
+  applyTemplate,
+  extractArguments,
+  processDisplayArgument,
+  processConditionExpression,
+  handleFunctionCall,
+  styleModule
+};
+
+if (typeof window !== 'undefined') {
+  window.processDisplayArgument = processDisplayArgument;
+  window.handleFunctionCall = handleFunctionCall;
+  window.normalizeParentheses = normalizeParentheses;
+  window.processConditionExpression = processConditionExpression;
+}
+// 這個模組的功能是將中文語句轉換為 JavaScript 語句，
+// 並且支援物件屬性和中文樣式屬性轉換。
+
+},{"./arrayModule.js":1,"./colorMap.js":2,"./dialogModule.js":3,"./imageModule.js":4,"./inputModule.js":5,"./logModule.js":6,"./mathModule.js":7,"./mediaModule.js":8,"./objectModule.js":9,"./soundModule.js":11,"./stringModule.js":12,"./styleModule.js":13,"./textModule.js":14,"./timeModule.js":15,"./vocabulary_map.json":16}],11:[function(require,module,exports){
+module.exports = {
+  播放音效: (src) => `new Audio(${src}).play()`
+};
+
+},{}],12:[function(require,module,exports){
+// stringModule.js
+module.exports = {
+  轉大寫: (input) => `${input}.toUpperCase()`,
+  包含: (str, substr) => `${str}.includes(${substr})`,
+  長度: (input) => `${input}.length`
+};
+
+},{}],13:[function(require,module,exports){
+module.exports = {
+  設定樣式: (selector, styleProp, value) => {
+    const propMap = {
+      背景色: 'backgroundColor',
+      文字顏色: 'color',
+      字型大小: 'fontSize',
+      邊框: 'border',
+      寬度: 'width',
+      高度: 'height'
+    };
+
+    const cleanProp = propMap[styleProp.replace(/['"]/g, '')] || styleProp.replace(/['"]/g, '');
+    const cleanValue = value.replace(/^["']|["']$/g, ''); // 🔥 去掉 value 最外層引號
+
+    return `document.querySelector(${selector}).style["${cleanProp}"] = "${cleanValue}"`;
+  },
+  隱藏元素: (selector) => {
+    return `document.querySelector(${selector}).style.display = "none"`;
+  },
+  隱藏: (selector) => {
+    return `document.querySelector(${selector}).style.display = "none"`;
+  },
+  顯示: (selector) => {
+    return `document.querySelector(${selector}).style.display = "block"`;
+  },
+  設定背景色: (selector, color) => {
+    const cleanColor = color.replace(/^['"]|['"]$/g, '');
+    return `document.querySelector(${selector}).style.backgroundColor = "${cleanColor}"`;
+  }
+};
+
+},{}],14:[function(require,module,exports){
+module.exports = {
+  設定文字內容: (selector, text) => {
+    return `document.querySelector(${selector}).textContent = ${text}`;
+  }
+};
+
+},{}],15:[function(require,module,exports){
+module.exports = {
+  獲取現在時間: () => 'new Date().toLocaleTimeString()',
+  顯示現在時間: () => 'alert(new Date().toLocaleString())',
+  顯示今天是星期幾: () =>
+    'alert("今天是星期" + "日一二三四五六"[new Date().getDay()])',
+  顯示現在是幾點幾分: () =>
+    'alert("現在是" + new Date().getHours() + "點" + new Date().getMinutes() + "分")'
+};
+
+},{}],16:[function(require,module,exports){
+module.exports={
+    "轉大寫": {
+        "module": "stringModule",
+        "js": "$1.toUpperCase()"
+    },
+    "包含": {
+        "module": "stringModule",
+        "js": "$1.includes($2)"
+    },
+    "隨機一個數": {
+        "module": "mathModule",
+        "js": "Math.floor(Math.random() * $1)"
+    },
+    "四捨五入": {
+        "module": "mathModule",
+        "js": "Math.round($1)"
+    },
+    "平方": {
+        "module": "mathModule",
+        "js": "Math.pow($1, 2)"
+    },
+    "建立人物": {
+        "module": "objectModule",
+        "js": "let 人物 = { 名字: \"$1\", 年齡: $2 }"
+    },
+    "取得屬性": {
+        "module": "objectModule",
+        "js": "$1[$2]"
+    },
+    "顯示訊息框": {
+        "module": "dialogModule",
+        "js": "alert($1)"
+    },
+    "使用者輸入": {
+        "module": "inputModule",
+        "js": "prompt($1)"
+    },
+    "設定樣式": {
+        "module": "styleModule",
+        "js": "styleModule.設定樣式($1, $2, $3)"
+    },
+    "設定背景色": {
+        "module": "styleModule",
+        "js": "styleModule.設定背景色($1, $2)"
+    },
+    "建立物件": {
+        "module": "objectModule",
+        "js": "ObjectModule.建立物件($1, $2, $3, $4)"
+    },
+    "顯示清單長度": {
+        "module": "arrayModule",
+        "js": "$1.length"
+    },
+    "清空清單": {
+        "module": "arrayModule",
+        "js": "$1.length = 0"
+    },
+    "判斷是否為空": {
+        "module": "arrayModule",
+        "js": "$1.length === 0"
+    },
+    "切換顏色": {
+        "module": "styleModule",
+        "js": "$1.style.backgroundColor = ($1.style.backgroundColor === '$2' ? '$3' : '$2')"
+    },
+    "隱藏元素": {
+        "module": "styleModule",
+        "js": "styleModule.隱藏元素($1)"
+    },
+    "隱藏": {
+        "module": "styleModule",
+        "js": "styleModule.隱藏($1)"
+    },
+    "顯示": {
+        "module": "styleModule",
+        "js": "styleModule.顯示($1)"
+    },
+    "切換顯示隱藏": {
+        "module": "styleModule",
+        "js": "const el = document.querySelector($1); el.style.display = el.style.display === 'none' ? 'block' : 'none'"
+    },
+    "播放影片": {
+        "module": "mediaModule",
+        "js": "$1.play()"
+    },
+    "暫停音效": {
+        "module": "mediaModule",
+        "js": "$1.pause()"
+    },
+    "獲取現在時間": {
+        "module": "timeModule",
+        "js": "new Date().toLocaleTimeString()"
+    },
+    "顯示現在時間": {
+        "module": "timeModule",
+        "js": "alert(new Date().toLocaleString())"
+    },
+    "顯示今天是星期幾": {
+        "module": "timeModule",
+        "js": "alert(\"今天是星期\" + \"日一二三四五六\"[new Date().getDay()])"
+    },
+    "顯示現在是幾點幾分": {
+        "module": "timeModule",
+        "js": "alert(\"現在是\" + new Date().getHours() + \"點\" + new Date().getMinutes() + \"分\")"
+    },
+    "替換文字": {
+        "module": "stringModule",
+        "js": "$1.replace($2, $3)"
+    },
+    "轉跳網頁": {
+        "module": "core",
+        "js": "window.location.href = $1"
+    },
+    "顯示圖片": {
+        "module": "imageModule",
+        "js": "imageModule.顯示圖片($1, $2)"
+    },
+    "播放音效": {
+        "module": "soundModule",
+        "js": "new Audio($1).play()"
+    },
+    "設定文字內容": {
+        "module": "textModule",
+        "js": "textModule.設定文字內容($1, $2)"
+    },
+    "說一句話": {
+        "module": "logModule",
+        "js": "logModule.說一句話($1)"
+    }
+}
+
+},{}]},{},[10])(10)
+});

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
     <!-- 模組載入順序建議：先載 array，再載核心邏輯 -->
     <script src="blang-modules/array.js"></script>
     <script src="errorHelper.js"></script>
-    <script src="blangSyntaxAPI.js"></script>
-    <script src="semanticHandler-v0.9.4.js"></script>
+    <script src="dist/blangSyntaxAPI.browser.js"></script>
+    <script src="dist/semanticHandler-v0.9.4.browser.js"></script>
     <script src="parser.js"></script>
 
     <script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,2183 @@
   "packages": {
     "": {
       "name": "blang-language",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "devDependencies": {
+        "browserify": "^17.0.1"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assert": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.1.tgz",
+      "integrity": "sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object.assign": "^4.1.4",
+        "util": "^0.10.4"
+      }
+    },
+    "node_modules/assert/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/assert/node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
+      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browser-pack": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
+      },
+      "bin": {
+        "browser-pack": "bin/cmd.js"
+      }
+    },
+    "node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
+    "node_modules/browserify": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.1.tgz",
+      "integrity": "sha512-pxhT00W3ylMhCHwG5yfqtZjNnFuX5h2IJdaBfSo4ChaaBsIp9VLrEMQ1bHV+Xr1uLPXuNDDM1GlJkjli0qkRsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "~5.2.1",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.1",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^3.0.0",
+        "glob": "^7.1.0",
+        "hasown": "^2.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.2.1",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp-classic": "^0.5.2",
+        "module-deps": "^6.2.3",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "^1.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum-object": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.0.0",
+        "string_decoder": "^1.1.1",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.1",
+        "url": "~0.11.0",
+        "util": "~0.12.0",
+        "vm-browserify": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+      "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.5",
+        "hash-base": "~3.0",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.7",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cached-path-relative": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
+      "integrity": "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/combine-source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "integrity": "sha512-UlxQ9Vw0b/Bt/KYwCFqdEwsQ1eL8d1gibiFb7lxQJFdvTgc2hIZi6ugsg+kyhzhPV+QEpUiEIwInIAIrgoEkrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dash-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deps-sort": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+      "integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "JSONStream": "^1.0.3",
+        "shasum-object": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
+      },
+      "bin": {
+        "deps-sort": "bin/cmd.js"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/detective": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
+      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.8.2",
+        "defined": "^1.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "detective": "bin/detective.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/htmlescape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha512-eVcrzgbR4tim7c7soKQKtxa/kQM4TzjnlU83rcZ9bHU6t31ehfV7SktN6McWgwPWg+JYMA/O3qpGxBvFq1z2Jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inline-source-map": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.3.tgz",
+      "integrity": "sha512-1aVsPEsJWMJq/pdMU61CDlm1URcW702MTB4w9/zUjMus6H/Py8o7g68Pr9D4I6QluWGt/KdmswuRhaA05xVR1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/insert-module-globals": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+      "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "insert-module-globals": "bin/cmd.js"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/labeled-stream-splicer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+      "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "stream-splicer": "^2.0.0"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-deps": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
+      "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-resolve": "^2.0.0",
+        "cached-path-relative": "^1.0.2",
+        "concat-stream": "~1.6.0",
+        "defined": "^1.0.0",
+        "detective": "^5.2.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.4.0",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "module-deps": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-platform": "~0.11.15"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+      "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "hash-base": "~3.0",
+        "pbkdf2": "^3.1.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha512-3ALe0bjBVZtkdWKIcThYpQCLbBMd/+Tbh2CDSrAIDO3UsZ4Xs+tnyjv2MjCOMMgBG+AsUOeuP1cgtY1INISc8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/shasum-object": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.0.tgz",
+      "integrity": "sha512-Iqo5rp/3xVi6M4YheapzZhhGPVs0yZwHj7wvwQ1B9z8H6zk+FEnI7y3Teq7qwnekfEhu8WmG2z0z4iWZaxLWVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/stream-http/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/stream-splicer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.1.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/syntax-error": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.2.0"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
+      "dev": true,
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/umd": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "umd": "bin/cli.js"
+      }
+    },
+    "node_modules/undeclared-identifiers": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+      "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn-node": "^1.3.0",
+        "dash-ast": "^1.0.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
+      },
+      "bin": {
+        "undeclared-identifiers": "bin.js"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "scripts": {
     "test": "node tests/run-tests.js",
     "build-doc": "node buildGrammarDoc.js"
+  },
+  "devDependencies": {
+    "browserify": "^17.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- bundle `blangSyntaxAPI.js` and `semanticHandler-v0.9.4.js` for browser usage
- expose global functions from the bundles
- load the new browser bundles in the demo page
- track `dist/` files and update npm metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685170ac243883279d2579a105bf1172