### PR TITLE
Add syntax example tests

### DIFF
--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const { execSync } = require('child_process');
 const { processDisplayArgument } = require('../semanticHandler-v0.9.4.js');
 const { testPatternSyntax } = require('./pattern-syntax.test');
+const { testSyntaxExamples } = require('./syntaxExamples.test');
 
 function testProcessDisplayArgument() {
   const declaredVars = new Set(['key']);
@@ -660,6 +661,7 @@ try {
   testIfElsePattern();
   testIfElsePatternChinese();
   testGetRegisteredPatterns();
+  testSyntaxExamples();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed:\n', err.message);

--- a/tests/syntaxExamples.test.js
+++ b/tests/syntaxExamples.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const parseBlang = require('../parser.js');
+const { runBlangParser } = require('../blangSyntaxAPI.js');
+
+function testSyntaxExamples() {
+  const cases = [
+    {
+      phrase: '顯示("你好")',
+      expected: 'alert("你好");'
+    },
+    {
+      phrase: '建立清單(清單)',
+      expected: 'let 清單 = ArrayModule.建立清單();'
+    },
+    {
+      phrase: '加入 "x" 到 清單',
+      expected: 'ArrayModule.加入項目("清單", "x");'
+    },
+    {
+      phrase: '顯示(輸入框.內容)',
+      expected: 'alert(輸入框.內容);'
+    }
+  ];
+
+  cases.forEach(({ phrase, expected }) => {
+    const js1 = parseBlang(phrase).trim();
+    const js2 = runBlangParser([phrase]).trim();
+    assert.strictEqual(js1, js2, `parseBlang and runBlangParser results differ for ${phrase}`);
+    assert(js1.includes(expected), `Result for "${phrase}" should contain "${expected}"`);
+  });
+}
+
+module.exports = { testSyntaxExamples };


### PR DESCRIPTION
## Summary
- create **tests/syntaxExamples.test.js** covering a few sample phrases
- execute the new test in `run-tests.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68525caf86788327b5c40e20f78011ad