### PR TITLE
Add AI reply placeholder module

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ node parser_v0.9.4.js
   在瀏覽器透過 `Function`，在 Node.js 則使用 `vm.runInNewContext`，
   因此能直接觸發 `alert`、`setTimeout`、播放音效等效果。
 
+> **AI 回覆**：當語句產生 `呼叫AI回覆(...)` 時，系統會呼叫 `aiModule.js` 中的占位函式，
+> 它僅會在畫面或主控台顯示「AI 回覆尚未實作」及給定訊息。
+
 ---
 
 ## ✨ 語法示範（中文程式邏輯）

--- a/aiModule.js
+++ b/aiModule.js
@@ -1,0 +1,14 @@
+function 呼叫AI回覆(msg) {
+  const text = typeof msg === 'undefined' ? '' : String(msg);
+  if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+    window.alert(`AI 回覆尚未實作: ${text}`);
+  } else {
+    console.log('AI 回覆尚未實作:', text);
+  }
+}
+if (typeof window !== 'undefined') {
+  window.呼叫AI回覆 = 呼叫AI回覆;
+} else if (typeof global !== 'undefined') {
+  global.呼叫AI回覆 = 呼叫AI回覆;
+}
+module.exports = { 呼叫AI回覆 };

--- a/dist/blangSyntaxAPI.browser.js
+++ b/dist/blangSyntaxAPI.browser.js
@@ -475,6 +475,7 @@ const textModule = require('./textModule.js');
 const arrayModule = require('./arrayModule.js');
 const vocabularyMap = require('./vocabulary_map.json');
 const colorMap = require('./colorMap.js');
+require('./aiModule.js');
 
 const modules = {
   stringModule,

--- a/patterns/array.js
+++ b/patterns/array.js
@@ -34,4 +34,9 @@ module.exports = function registerArrayPatterns(definePattern) {
     (清單) => `${清單}.reverse();`,
     { type: 'data', description: 'reverse list' }
   );
+  definePattern(
+    '加入項目($清單, $項目)',
+    (清單, 項目) => `ArrayModule.加入項目(${清單}, ${項目});`,
+    { type: 'data', description: 'direct add item' }
+  );
 };

--- a/patterns/display.js
+++ b/patterns/display.js
@@ -101,6 +101,11 @@ module.exports = function registerDisplayPatterns(definePattern) {
     (檔名) => `const a = new Audio(${檔名}); a.loop = true; a.play();`,
     { type: 'media', description: 'loop audio' }
   );
+  definePattern(
+    '顯示內容($內容)',
+    (內容) => `console.log(${內容})`,
+    { type: 'log', description: 'console output' }
+  );
   definePattern('顯示 $內容', (內容) => `alert(${內容});`, {
     description: '彈出警示框顯示指定內容',
     hints: ['內容']

--- a/semanticHandler-v0.9.4.js
+++ b/semanticHandler-v0.9.4.js
@@ -15,6 +15,7 @@ const textModule = require('./textModule.js');
 const arrayModule = require('./arrayModule.js');
 const vocabularyMap = require('./vocabulary_map.json');
 const colorMap = require('./colorMap.js');
+require('./aiModule.js');
 
 const modules = {
   stringModule,


### PR DESCRIPTION
## Summary
- add `aiModule.js` with global `呼叫AI回覆` placeholder
- load placeholder in `semanticHandler-v0.9.4.js` and browser build
- expose message about placeholder in README
- update patterns and tests support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685269ca6320832785a431d625b37189