### PR TITLE
Add console log pattern for 顯示內容

### DIFF
--- a/logModule.js
+++ b/logModule.js
@@ -2,5 +2,9 @@ module.exports = {
   說一句話: (text) => {
     const clean = /^['"].*['"]$/.test(text.trim()) ? text : `"${text}"`;
     return `console.log(${clean})`;
+  },
+  顯示內容: (text) => {
+    const clean = /^['"].*['"]$/.test(text.trim()) ? text : `"${text}"`;
+    return `console.log(${clean})`;
   }
 };

--- a/patterns/array.js
+++ b/patterns/array.js
@@ -21,6 +21,15 @@ module.exports = function registerArrayPatterns(definePattern) {
     { type: 'data', description: 'append item to list' }
   );
   definePattern(
+    '加入項目($清單, $項目)',
+    (清單, 項目) => {
+      const list = 清單.trim();
+      const item = processDisplayArgument(項目);
+      return `ArrayModule.加入項目(${list}, ${item});`;
+    },
+    { type: 'data', description: 'append item to list directly' }
+  );
+  definePattern(
     '把 $項目 加進 $清單',
     (項目, 清單) => {
       const item = processDisplayArgument(項目);

--- a/patterns/logic.js
+++ b/patterns/logic.js
@@ -79,6 +79,11 @@ module.exports = function registerLogicPatterns(definePattern) {
     { type: 'log', description: 'console output' }
   );
   definePattern(
+    '顯示內容($內容)',
+    (內容) => `console.log(${內容});`,
+    { type: 'log', description: 'console output' }
+  );
+  definePattern(
     '顯示隨機整數至 $最大值',
     (最大值) => `alert(Math.floor(Math.random() * ${最大值}));`,
     { type: 'math', description: 'random integer' }

--- a/vocabulary_map.json
+++ b/vocabulary_map.json
@@ -126,5 +126,9 @@
     "說一句話": {
         "module": "logModule",
         "js": "logModule.說一句話($1)"
+    },
+    "顯示內容": {
+        "module": "logModule",
+        "js": "logModule.顯示內容($1)"
     }
 }


### PR DESCRIPTION
## Summary
- enable `顯示內容("text")` to log to console
- map new log helper in vocabulary map
- expose `顯示內容` helper in logModule
- support direct list item addition pattern

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685269ddc334832785bb23d08df5c0b8