### PR TITLE
Add function call parsing and tests

### DIFF
--- a/patterns/general.js
+++ b/patterns/general.js
@@ -1,0 +1,12 @@
+const { handleFunctionCall } = require('../semanticHandler-v0.9.4.js');
+
+module.exports = function registerGeneralPatterns(definePattern) {
+  definePattern(
+    '$函式名($參數)',
+    (函式名, 參數) => {
+      if (函式名 === '顯示') return `alert(${參數});`;
+      return handleFunctionCall(函式名, 參數);
+    },
+    { type: 'function', description: 'direct function call' }
+  );
+};

--- a/patterns/index.js
+++ b/patterns/index.js
@@ -1,9 +1,11 @@
 const arrayPatterns = require('./array');
 const displayPatterns = require('./display');
 const logicPatterns = require('./logic');
+const generalPatterns = require('./general');
 
 module.exports = function registerPatterns(definePattern) {
   logicPatterns(definePattern);
   arrayPatterns(definePattern);
   displayPatterns(definePattern);
+  generalPatterns(definePattern);
 };

--- a/patterns/logic.js
+++ b/patterns/logic.js
@@ -1,3 +1,5 @@
+const { handleFunctionCall } = require('../semanticHandler-v0.9.4.js');
+
 module.exports = function registerLogicPatterns(definePattern) {
   definePattern(
     '設定 cookie $名稱 為 $值',
@@ -79,6 +81,11 @@ module.exports = function registerLogicPatterns(definePattern) {
     { type: 'log', description: 'console output' }
   );
   definePattern(
+    '顯示內容($內容)',
+    (內容) => `console.log(${內容});`,
+    { type: 'log', description: 'console output' }
+  );
+  definePattern(
     '顯示隨機整數至 $最大值',
     (最大值) => `alert(Math.floor(Math.random() * ${最大值}));`,
     { type: 'math', description: 'random integer' }
@@ -92,5 +99,17 @@ module.exports = function registerLogicPatterns(definePattern) {
     '開新視窗到 $網址',
     (網址) => `window.open(${網址}, '_blank');`,
     { type: 'control', description: 'open new window' }
+  );
+
+  // 新增函式定義與呼叫相關樣式
+  definePattern(
+    '定義 $函式名($參數)：',
+    (函式名, 參數) => `function ${函式名}(${參數}) {`,
+    { type: 'function', description: 'define a function' }
+  );
+  definePattern(
+    '呼叫 $函式名($參數)',
+    (函式名, 參數) => handleFunctionCall(函式名, 參數),
+    { type: 'function', description: 'call a function' }
   );
 };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -640,6 +640,28 @@ function testAddItemDirectPattern() {
   );
 }
 
+function testFunctionDefinitionPattern() {
+  const { runBlangParser } = require('../blangSyntaxAPI.js');
+  const lines = ['定義 打招呼(名字)：'];
+  const result = runBlangParser(lines).trim();
+  assert.strictEqual(
+    result,
+    'function 打招呼(名字) {',
+    'function definition pattern should translate correctly'
+  );
+}
+
+function testFunctionCallPattern() {
+  const { runBlangParser } = require('../blangSyntaxAPI.js');
+  const lines = ['呼叫 打招呼("小明")'];
+  const result = runBlangParser(lines).trim();
+  assert.strictEqual(
+    result,
+    '打招呼("小明");',
+    'function call pattern should translate correctly'
+  );
+}
+
 function testGetRegisteredPatterns() {
   const { getRegisteredPatterns } = require('../blangSyntaxAPI.js');
   const patterns = getRegisteredPatterns();
@@ -693,6 +715,8 @@ try {
   testIfElsePattern();
   testIfElsePatternChinese();
   testAddItemDirectPattern();
+  testFunctionDefinitionPattern();
+  testFunctionCallPattern();
   testGetRegisteredPatterns();
   testSyntaxExamples();
   console.log('All tests passed');


### PR DESCRIPTION
## Summary
- register new direct function call pattern
- handle function definitions and calls in logic patterns
- ensure pattern registration order adds direct calls last
- test function definition and call parsing

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_685269dfd9c483278ef3fd85558bbe9f