### PR TITLE
Add cache-busting query to script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,8 +90,8 @@
     <!-- 模組載入順序建議：先載 array，再載核心邏輯 -->
     <script src="blang-modules/array.js"></script>
     <script src="errorHelper.js"></script>
-    <script src="dist/blangSyntaxAPI.browser.js"></script>
-    <script src="dist/semanticHandler.browser.js"></script>
+    <script src="dist/blangSyntaxAPI.browser.js?ver=1"></script>
+    <script src="dist/semanticHandler.browser.js?ver=1"></script>
     <script src="variableHints.js"></script>
     <script src="parser.js"></script>
 


### PR DESCRIPTION
## Summary
- tweak script tags to include `ver=1` query parameter for caching control

## Testing
- `npm test` *(fails: Result for "顯示("你好")" should contain "style.display = "block"" )*

------
https://chatgpt.com/codex/tasks/task_e_6852770ac93083278c64ab19d41be76f