### PR TITLE
Update build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,11 @@ blang/
 
 ```bash
 npm run build-browser
+npm run build-blang-browser
 ```
 
-這會產生 `dist/semanticHandler.browser.js`，供瀏覽器環境使用。
+這會分別產生 `dist/semanticHandler.browser.js` 與 `dist/blangSyntaxAPI.browser.js`，供瀏覽器環境使用。
+在 `index.html` 中可於檔名後加入 `?v=1` 之類的查詢參數，避免瀏覽器快取舊版檔案。
 
 ## 🧪 測試與開發工具
 
@@ -279,6 +281,8 @@ node blang-lint.js
 ```bash
 npm run build-grammar-doc
 ```
+
+當你增修 `customBlangPatterns.js` 或其他語法規則時，再執行此指令以更新 `grammar_auto.md`。
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -90,8 +90,8 @@
     <!-- 模組載入順序建議：先載 array，再載核心邏輯 -->
     <script src="blang-modules/array.js"></script>
     <script src="errorHelper.js"></script>
-    <script src="dist/blangSyntaxAPI.browser.js"></script>
-    <script src="dist/semanticHandler.browser.js"></script>
+    <script src="dist/blangSyntaxAPI.browser.js?v=1"></script>
+    <script src="dist/semanticHandler.browser.js?v=1"></script>
     <script src="variableHints.js"></script>
     <script src="parser.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "test": "node tests/run-tests.js",
     "build-doc": "node buildGrammarDoc.js",
     "build-grammar-doc": "node buildGrammarDoc.js",
-    "build-browser": "browserify semanticHandler.js -s handleSyntax -o dist/semanticHandler.browser.js"
+    "build-browser": "browserify semanticHandler.js -s handleSyntax -o dist/semanticHandler.browser.js",
+    "build-blang-browser": "browserify blangSyntaxAPI.js -s blangSyntaxAPI -o dist/blangSyntaxAPI.browser.js"
   },
   "devDependencies": {
     "browserify": "^17.0.1"


### PR DESCRIPTION
## Summary
- add `build-blang-browser` script
- use query string for cache busting in demo
- document both build steps
- clarify when to rebuild grammar docs

## Testing
- `npm test` *(fails: Result for "顯示("你好")" should contain "style.display = "block")*
- `npm run build-browser` *(fails: browserify: not found)*
- `npm run build-blang-browser` *(fails: browserify: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852770ec5c88327a8cdf0b6bb83e39e