### PR TITLE
Add error handling for demo parse failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,14 @@
           document.getElementById('結果區').innerText = result ?? '✅ 執行成功';
           if (!message) document.getElementById('console_log').innerText = '';
         } catch (e) {
-          document.getElementById('console_log').innerText = e.message;
+          const msg = e && e.message ? e.message : String(e);
+          if (msg.includes('無法辨識語句')) {
+            console.warn('無法解析語句：', input);
+            document.getElementById('console_log').innerText =
+              '⚠️ 無法辨識語句，請確認語法正確或參考語句範例。';
+          } else {
+            document.getElementById('console_log').innerText = msg;
+          }
         }
       });
     </script>

--- a/parser.js
+++ b/parser.js
@@ -9,7 +9,14 @@
 
   function parseBlang(code){
     const lines = Array.isArray(code) ? code : String(code).split(/\r?\n/);
-    const result = runBlangParser(lines).trim();
+    let result;
+    try {
+      result = runBlangParser(lines).trim();
+    } catch(err){
+      const msg = ErrorHelper && ErrorHelper.translateError ?
+        ErrorHelper.translateError(err) : (err && err.message) || String(err);
+      throw new Error(msg);
+    }
     if(result.startsWith('// 無法辨識語句')){
       const msg = ErrorHelper && ErrorHelper.translateError ?
         ErrorHelper.translateError(new Error(result)) : result;


### PR DESCRIPTION
## Summary
- improve `parseBlang` with try/catch to surface internal errors
- show user-friendly error message when parsing fails in the demo page
- log unrecognized phrases in console

## Testing
- `npm test` *(fails: Result for "顯示("你好")" should contain "style.display = "block""*)

------
https://chatgpt.com/codex/tasks/task_e_685279294f8483278bd5adc105b2a0c3