### PR TITLE
Add array helpers

### DIFF
--- a/arrayModule.js
+++ b/arrayModule.js
@@ -1,3 +1,9 @@
 module.exports = {
-  加入項目: (list, item) => `ArrayModule.加入項目(${list}, ${item})`
+  加入項目: (list, item) => `ArrayModule.加入項目(${list}, ${item})`,
+
+  顯示第幾項: (list, index) => `${list}[${index} - 1]`,
+
+  取得項目: (list, index) => `${list}[${index} - 1]`,
+
+  清空清單: (list) => `${list}.length = 0`
 };

--- a/semanticHandler-v0.9.4.js
+++ b/semanticHandler-v0.9.4.js
@@ -39,6 +39,8 @@ const FUNC_MAP = {
   移除最後: 'ArrayModule.移除最後',
   顯示全部: 'ArrayModule.顯示全部',
   顯示第幾項: 'ArrayModule.顯示第幾項',
+  取得項目: 'ArrayModule.取得項目',
+  清空清單: 'ArrayModule.清空清單',
   'AI 回覆': 'DialogModule.AI回覆',
   顯示訊息框: 'DialogModule.顯示訊息框',
   播放音效: 'soundModule.播放音效',

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -686,6 +686,25 @@ function testClearListPattern() {
   assert.strictEqual(result, 'A.length = 0;', '清空清單 should translate to length reset');
 }
 
+function testArrayModuleHelpers() {
+  const arrayModule = require('../arrayModule.js');
+  assert.strictEqual(
+    arrayModule.顯示第幾項('list', '2'),
+    'list[2 - 1]',
+    '顯示第幾項 should return index lookup string'
+  );
+  assert.strictEqual(
+    arrayModule.取得項目('list', '3'),
+    'list[3 - 1]',
+    '取得項目 should return index lookup string'
+  );
+  assert.strictEqual(
+    arrayModule.清空清單('list'),
+    'list.length = 0',
+    '清空清單 should return length reset string'
+  );
+}
+
 function testVocabularyMapParsing() {
   const { runBlangParser } = require('../blangSyntaxAPI.js');
   const lines = ['說一句話("嗨")'];
@@ -771,6 +790,7 @@ try {
   testAddItemDirectPattern();
   testGetItemPattern();
   testClearListPattern();
+  testArrayModuleHelpers();
   testVocabularyMapParsing();
   testGetRegisteredPatterns();
   testSyntaxExamples();


### PR DESCRIPTION
## Summary
- expand `arrayModule.js` with helpers for fetching and clearing items
- register `取得項目` and `清空清單` in `semanticHandler-v0.9.4.js`
- cover new helpers with tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685292a0be9c832785a08f7af9101ccb