### PR TITLE
Refactor parser special cases

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -176,37 +176,6 @@ function parseBlang(text) {
   if (!line) continue;
 
 
-  if (line.startsWith('顯示圖片(') && line.includes('在 #')) {
-    const m = line.match(/顯示圖片[（(](.*?) 在 #(.*?)[)）]/);
-    if (m) {
-      const src = m[1].trim();
-      const target = `"#${m[2].trim()}"`;
-      output.push(' '.repeat(indent) + handleFunctionCall('顯示圖片', `${src}, ${target}`, indent, declaredVars));
-      continue;
-    }
-  }
-
-  if (line.startsWith('顯示(') && line.includes('在 #')) {
-    const match = line.match(/顯示\((.*?) 在 #(.*?)\)/); // ex: 顯示("你是：" + 名字 在 #name)
-    if (match) {
-      const rawExpr = match[1].trim();
-      const targetId = match[2].trim();
-
-      // 處理內容中的每個片段（可能是變數或字串）
-      const parts = rawExpr.split(/\s*\+\s*/).map((part) => {
-        const trimmed = part.trim();
-        if (/^[A-Za-z_]+Module\.\w+/.test(trimmed)) {
-          return trimmed; // 直接保留
-        }
-        return processDisplayArgument(trimmed, declaredVars);
-      });
-      output.push(
-        ' '.repeat(indent) +
-          `document.getElementById('${targetId}').innerText = ${parts.join(' + ')};`
-      );
-      continue;
-    }
-  }
 
   if (
     line.startsWith('定義 ') &&
@@ -483,70 +452,6 @@ function parseBlang(text) {
     }
   }
 
-  if (line.match(/^切換顏色[（(].*[)）]$/)) {
-    const m = line.match(/切換顏色[（(](.*?),\s*(.*?),\s*(.*)[)）]/);
-    if (m) {
-      const sel = processDisplayArgument(m[1].trim(), declaredVars);
-      const c1 = processDisplayArgument(m[2].trim(), declaredVars);
-      const c2 = processDisplayArgument(m[3].trim(), declaredVars);
-      const elVar = `__toggleEl${toggleColorCounter++}`;
-      output.push(' '.repeat(indent) + `let ${elVar} = document.querySelector(${sel});`);
-      output.push(
-        ' '.repeat(indent) +
-          `${elVar}.style.color = ${elVar}.style.color === ${c1} ? ${c2} : ${c1};`
-      );
-      continue;
-    }
-  }
-
-
-
-
-  if (line.match(/^獲取現在時間[（(].*[)）]$/) || line.trim() === '獲取現在時間()') {
-    output.push(' '.repeat(indent) + 'new Date().toLocaleTimeString();');
-    continue;
-  }
-
-  if (line.trim() === '顯示現在時間') {
-    output.push(' '.repeat(indent) + 'alert(new Date().toLocaleString());');
-    continue;
-  }
-
-  if (line.trim() === '顯示今天是星期幾') {
-    output.push(
-      ' '.repeat(indent) +
-        'alert("今天是星期" + "日一二三四五六"[new Date().getDay()]);'
-    );
-    continue;
-  }
-
-  if (line.trim() === '顯示現在是幾點幾分') {
-    output.push(
-      ' '.repeat(indent) +
-        'alert("現在是" + new Date().getHours() + "點" + new Date().getMinutes() + "分");'
-    );
-    continue;
-  }
-
-  if (line.match(/^替換文字[（(].*[)）]$/)) {
-    const m = line.match(/替換文字[（(](.*?),\s*(.*?),\s*(.*)[)）]/);
-    if (m) {
-      const str = processDisplayArgument(m[1].trim(), declaredVars);
-      const from = processDisplayArgument(m[2].trim(), declaredVars);
-      const to = processDisplayArgument(m[3].trim(), declaredVars);
-      output.push(' '.repeat(indent) + `${str}.replace(${from}, ${to});`);
-      continue;
-    }
-  }
-
-  if (line.match(/^轉跳網頁[（(].*[)）]$/)) {
-    const m = line.match(/轉跳網頁[（(](.*)[)）]/);
-    if (m) {
-      const url = processDisplayArgument(m[1].trim(), declaredVars);
-      output.push(' '.repeat(indent) + `window.location.href = ${url};`);
-      continue;
-    }
-  }
 
 
   if (line.startsWith('顯示(') || line.startsWith('顯示（')) {
@@ -592,12 +497,6 @@ function parseBlang(text) {
     }
   }
 
-  // ✅ 支援「隱藏 #id」簡寫
-  if (/^隱藏\s+#.+/.test(line.trim())) {
-    const selector = line.trim().replace(/^隱藏\s+/, '');
-    output.push(' '.repeat(indent) + handleFunctionCall('隱藏', selector, indent, declaredVars));
-    continue;
-  }
 
   // ✅ 一般函式語句處理：如 設定樣式(...)、轉大寫(...)、使用者輸入(...)
   if (

--- a/patterns/display.js
+++ b/patterns/display.js
@@ -9,7 +9,7 @@ module.exports = function registerDisplayPatterns(definePattern) {
   );
   definePattern(
     '隱藏 $元素',
-    (元素) => `document.querySelector('${元素}').style.display = "none";`,
+    (元素) => handleFunctionCall('隱藏', 元素),
     { type: 'ui', description: '隱藏指定元素', hints: ['元素'] }
   );
   definePattern(
@@ -18,12 +18,21 @@ module.exports = function registerDisplayPatterns(definePattern) {
       `document.querySelector('${選擇器}').textContent = ${訊息};`,
     { type: 'ui', description: 'update DOM text content' }
   );
-  // vocabulary_map.json handles 顯示圖片 and 設定背景色
   definePattern(
-    '切換顏色($選擇器, $顏色1, $顏色2)',
-    (選擇器, 顏色1, 顏色2) => {
+    '顯示圖片($路徑 在 $選擇器)',
+    (路徑, 選擇器) => handleFunctionCall('顯示圖片', `${路徑}, ${選擇器}`),
+    { type: 'ui', description: 'append image to selector' }
+  );
+  // vocabulary_map.json handles 設定背景色
+  definePattern(
+    '切換顏色($參數)',
+    (參數) => {
+      const [選擇器, 顏色1, 顏色2] = 參數.split(/\s*,\s*/);
+      const sel = processDisplayArgument(選擇器);
+      const c1 = processDisplayArgument(顏色1);
+      const c2 = processDisplayArgument(顏色2);
       const elVar = `__toggleEl${toggleId++}`;
-      return `let ${elVar} = document.querySelector('${選擇器}'); ${elVar}.style.color = ${elVar}.style.color === ${顏色1} ? ${顏色2} : ${顏色1};`;
+      return `let ${elVar} = document.querySelector(${sel}); ${elVar}.style.color = ${elVar}.style.color === ${c1} ? ${c2} : ${c1};`;
     },
     { type: 'ui', description: 'toggle text color' }
   );

--- a/styleModule.js
+++ b/styleModule.js
@@ -1,3 +1,5 @@
+const colorMap = require('./colorMap.js');
+
 module.exports = {
   設定樣式: (selector, styleProp, value) => {
     const propMap = {
@@ -26,5 +28,14 @@ module.exports = {
   設定背景色: (selector, color) => {
     const cleanColor = color.replace(/^['"]|['"]$/g, '');
     return `document.querySelector(${selector}).style.backgroundColor = "${cleanColor}"`;
-  }
+  },
+  切換顏色: (() => {
+    let id = 0;
+    return (selector, c1, c2) => {
+      const varName = `__toggleEl${id++}`;
+      const color1 = colorMap[c1.replace(/^["']|["']$/g, '')] ? `"${colorMap[c1.replace(/^["']|["']$/g, '')]}"` : c1;
+      const color2 = colorMap[c2.replace(/^["']|["']$/g, '')] ? `"${colorMap[c2.replace(/^["']|["']$/g, '')]}"` : c2;
+      return `let ${varName} = document.querySelector(${selector}); ${varName}.style.color = ${varName}.style.color === ${color1} ? ${color2} : ${color1}`;
+    };
+  })()
 };

--- a/vocabulary_map.json
+++ b/vocabulary_map.json
@@ -61,7 +61,7 @@
     },
     "切換顏色": {
         "module": "styleModule",
-        "js": "$1.style.backgroundColor = ($1.style.backgroundColor === '$2' ? '$3' : '$2')"
+        "js": ""
     },
     "隱藏元素": {
         "module": "styleModule",


### PR DESCRIPTION
## Summary
- add pattern for `顯示圖片($路徑 在 $選擇器)`
- delegate `隱藏 $元素` and `切換顏色` to pattern helpers
- implement `切換顏色` in style module with color mapping
- allow vocabulary map to use the new helper
- remove obsolete hardcoded handling from parser

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685297cef4588327a987e9bf869bce9c