### PR TITLE
Add Levenshtein suggestions for unknown phrases

### DIFF
--- a/blangSyntaxAPI.js
+++ b/blangSyntaxAPI.js
@@ -9,6 +9,42 @@ function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
 }
 
+function levenshtein(a = '', b = '') {
+  const m = a.length,
+    n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+    }
+  }
+  return dp[m][n];
+}
+
+function stripPattern(p) {
+  return p.replace(/\$[\w\u4e00-\u9fa5_]+/g, '').replace(/[（）()]/g, '').trim();
+}
+
+function findClosestMatch(input) {
+  const candidates = [
+    ...patternRegistry.map((p) => stripPattern(p.pattern)),
+    ...Object.keys(vocabularyMap),
+  ];
+  let best = '';
+  let bestDist = Infinity;
+  for (const c of candidates) {
+    const d = levenshtein(input, c);
+    if (d < bestDist) {
+      bestDist = d;
+      best = c;
+    }
+  }
+  return best;
+}
+
 function definePattern(pattern, generator, options = {}) {
   const entry = { pattern, generator };
   if (options.description) entry.description = options.description;
@@ -94,7 +130,8 @@ function legacyParse(line) {
   if (assignMatch) {
     return `let ${assignMatch[1]} = ${assignMatch[2]};`;
   }
-  return '// 無法辨識語句：' + line;
+  const suggestion = findClosestMatch(line.trim());
+  return `// 無法辨識語句，是否想輸入：${suggestion}?`;
 }
 
 function buildRegexFromPattern(pattern) {
@@ -132,7 +169,8 @@ module.exports = {
   runBlangParser,
   buildRegexFromPattern,
   getRegisteredPatterns,
-  getPatternsByType
+  getPatternsByType,
+  findClosestMatch
 };
 
 if (typeof window !== 'undefined') {

--- a/index.html
+++ b/index.html
@@ -126,8 +126,9 @@
           const msg = e && e.message ? e.message : String(e);
           if (msg.includes('無法辨識語句')) {
             console.warn('無法解析語句：', input);
+            const suggestion = e && e.suggestion ? `，是否想輸入：${e.suggestion}?` : '';
             document.getElementById('console_log').innerText =
-              '⚠️ 無法辨識語句，請確認語法正確或參考語句範例。';
+              `⚠️ 無法辨識語句${suggestion}`;
           } else {
             document.getElementById('console_log').innerText = msg;
           }

--- a/parser.js
+++ b/parser.js
@@ -20,7 +20,10 @@
     if(result.startsWith('// 無法辨識語句')){
       const msg = ErrorHelper && ErrorHelper.translateError ?
         ErrorHelper.translateError(new Error(result)) : result;
-      throw new Error(msg);
+      const err = new Error(msg);
+      const m = result.match(/是否想輸入：(.+?)\?/);
+      if(m) err.suggestion = m[1];
+      throw err;
     }
     return result;
   }

--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -616,11 +616,7 @@ function parseBlang(text) {
   }
 
   const parsed = runBlangParser([line]).trim();
-  if (!parsed.startsWith('// 無法辨識語句')) {
-    output.push(' '.repeat(indent) + parsed);
-  } else {
-    output.push(' '.repeat(indent) + `// 未翻譯：${line}（無匹配的語法規則）`);
-  }
+  output.push(' '.repeat(indent) + parsed);
 }
 
   closeBlocks(0, 0);

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -756,6 +756,17 @@ function testGetRegisteredPatterns() {
   assert(Array.isArray(wait.hints), 'pattern should expose parameter hints');
 }
 
+function testMisspelledSuggestion() {
+  const parseBlang = require('../parser.js');
+  try {
+    parseBlang('顯示abc');
+    assert.fail('should throw on unknown phrase');
+  } catch (e) {
+    assert(e.suggestion, 'error should include suggestion');
+    assert.strictEqual(e.suggestion, '顯示內容', 'should suggest closest phrase');
+  }
+}
+
 try {
   testPatternSyntax();
   testProcessDisplayArgument();
@@ -793,6 +804,7 @@ try {
   testArrayModuleHelpers();
   testVocabularyMapParsing();
   testGetRegisteredPatterns();
+  testMisspelledSuggestion();
   testSyntaxExamples();
   console.log('All tests passed');
 } catch (err) {


### PR DESCRIPTION
## Summary
- implement Levenshtein matcher in `blangSyntaxAPI`
- return suggestion comment for unknown lines
- surface suggestion via `parseBlang` errors
- show suggestion in demo page
- test suggestion logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685297d6f5688327ae8342a440f9eb0f