### PR TITLE
Fix style module color map require

### DIFF
--- a/styleModule.js
+++ b/styleModule.js
@@ -1,3 +1,5 @@
+const colorMap = require('./colorMap.js');
+
 const hide = (selector) => {
   return `document.querySelector(${selector}).style.display = "none"`;
 };


### PR DESCRIPTION
## Summary
- require `colorMap` at the top of `styleModule.js`

## Testing
- `node parser_v0.9.4.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68529dd43ecc8327b4fa592b1c0ccc4d