### PR TITLE
Implement auto-declare for media selectors

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -130,7 +130,11 @@ function autoDeclareVariablesFromCondition(condition) {
     for (const v of vars) {
       if (!declaredVars.has(v) && isNaN(v) && !ignoreList.has(v)) {
         declaredVars.add(v);
-        output.unshift(`let ${v} = 0; // ⛳ 自動補上未宣告變數`);
+        if(/播放器$/.test(v)) {
+          output.unshift(`const ${v} = "#${v}"; // ⛳ 自動補上 DOM 選擇器變數`);
+        } else {
+          output.unshift(`let ${v} = 0; // ⛳ 自動補上未宣告變數`);
+        }
       }
     }
   }
@@ -145,7 +149,11 @@ function autoDeclareFromParams(params = '') {
     if (!/^[\u4e00-\u9fa5A-Za-z_][\w\u4e00-\u9fa5]*$/.test(token)) continue; // invalid identifier
     if (ignoreList.has(token) || declaredVars.has(token)) continue;
     declaredVars.add(token);
-    output.unshift(`let ${token} = 0; // ⛳ 自動補上未宣告變數`);
+    if(/播放器$/.test(token)) {
+      output.unshift(`const ${token} = "#${token}"; // ⛳ 自動補上 DOM 選擇器變數`);
+    } else {
+      output.unshift(`let ${token} = 0; // ⛳ 自動補上未宣告變數`);
+    }
   }
 }
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -480,6 +480,33 @@ function testPlayVideoParsing() {
   }
 }
 
+function testAutoDeclarePlayerSelector() {
+  const sample = '播放影片(影片播放器)';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('const 影片播放器 = "#影片播放器"'),
+    '未宣告的 影片播放器 應自動補成 DOM 選擇器字串'
+  );
+  assert(
+    output.includes('document.querySelector(影片播放器).play();'),
+    '播放影片 應使用自動補的選擇器變數'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testPauseAudioParsing() {
   const sample = '暫停音效(#audio)';
   const originalDemo = fs.readFileSync('demo.blang', 'utf8');
@@ -812,6 +839,7 @@ try {
   testLogStatement();
   testShowContentLog();
   testPlayVideoParsing();
+  testAutoDeclarePlayerSelector();
   testPauseAudioParsing();
   testPlaySoundParsing();
   testLoopAudioParsing();


### PR DESCRIPTION
## Summary
- auto-declare variables ending with `播放器` as selector strings
- add regression test for undeclared media element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cf6525888327b4db250128a4aee6