### PR TITLE
Add CLI variable checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,13 @@ node blang-lint.js
 
 系統雖會自動補上未宣告變數，但仍建議檢查程式邏輯以免埋下錯誤。
 
+在 Node 環境可直接檢查轉譯後的 `output.js`：
+
+```bash
+node scripts/check-vars.js output.js
+```
+
+
 ### 開發工具
 
 產生語法文件：

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build-grammar-doc": "node buildGrammarDoc.js",
     "build-browser": "browserify semanticHandler.js -s handleSyntax -o dist/semanticHandler.browser.js",
     "build-blang-browser": "browserify blangSyntaxAPI.js -s blangSyntaxAPI -o dist/blangSyntaxAPI.browser.js",
-    "build-api": "node parser_v0.9.4.js"
+    "build-api": "node parser_v0.9.4.js",
+    "lint:vars": "node scripts/check-vars.js output.js"
   },
   "devDependencies": {
     "browserify": "^17.0.1"

--- a/scripts/check-vars.js
+++ b/scripts/check-vars.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const variableHints = require('../variableHints');
+
+const targetFile = process.argv[2];
+if (!targetFile) {
+  console.error('Usage: node scripts/check-vars.js <file>');
+  process.exit(1);
+}
+
+const code = fs.readFileSync(path.resolve(process.cwd(), targetFile), 'utf8');
+const { message } = variableHints.getHints(code);
+console.log(message || 'No undeclared variables.');
+


### PR DESCRIPTION
## Summary
- add a `check-vars.js` helper script
- document the script in README
- expose `lint:vars` npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853d1dd7e508327b3b3d5c48fb3ec22