### PR TITLE
Add safe querySelector checks

### DIFF
--- a/imageModule.js
+++ b/imageModule.js
@@ -1,6 +1,7 @@
 module.exports = {
   顯示圖片: (src, selector) => {
     const cleanSrc = src.replace(/^["']|["']$/g, '');
-    return `const img = document.createElement('img'); img.src = "${cleanSrc}"; document.querySelector(${selector}).appendChild(img)`;
+    const elExpr = `document.querySelector(${selector})`;
+    return `const img = document.createElement('img'); img.src = "${cleanSrc}"; ${elExpr} && ${elExpr}.appendChild(img)`;
   }
 };

--- a/mediaModule.js
+++ b/mediaModule.js
@@ -1,4 +1,10 @@
 module.exports = {
-  播放影片: (target) => `document.querySelector(${target}).play()`,
-  暫停音效: (target) => `document.querySelector(${target}).pause()`
+  播放影片: (target) => {
+    const elExpr = `document.querySelector(${target})`;
+    return `${elExpr} && ${elExpr}.play()`;
+  },
+  暫停音效: (target) => {
+    const elExpr = `document.querySelector(${target})`;
+    return `${elExpr} && ${elExpr}.pause()`;
+  }
 };

--- a/styleModule.js
+++ b/styleModule.js
@@ -1,7 +1,8 @@
 const colorMap = require('./colorMap.js');
 
 const hide = (selector) => {
-  return `document.querySelector(${selector}).style.display = "none"`;
+  const elExpr = `document.querySelector(${selector})`;
+  return `${elExpr} && (${elExpr}.style.display = "none")`;
 };
 
 module.exports = {
@@ -18,16 +19,19 @@ module.exports = {
     const cleanProp = propMap[styleProp.replace(/['"]/g, '')] || styleProp.replace(/['"]/g, '');
     const cleanValue = value.replace(/^["']|["']$/g, ''); // 🔥 去掉 value 最外層引號
 
-    return `document.querySelector(${selector}).style["${cleanProp}"] = "${cleanValue}"`;
+    const elExpr = `document.querySelector(${selector})`;
+    return `${elExpr} && (${elExpr}.style["${cleanProp}"] = "${cleanValue}")`;
   },
   隱藏: hide,
   隱藏元素: hide,
   顯示: (selector) => {
-    return `document.querySelector(${selector}).style.display = "block"`;
+    const elExpr = `document.querySelector(${selector})`;
+    return `${elExpr} && (${elExpr}.style.display = "block")`;
   },
   設定背景色: (selector, color) => {
     const cleanColor = color.replace(/^['"]|['"]$/g, '');
-    return `document.querySelector(${selector}).style.backgroundColor = "${cleanColor}"`;
+    const elExpr = `document.querySelector(${selector})`;
+    return `${elExpr} && (${elExpr}.style.backgroundColor = "${cleanColor}")`;
   },
   切換顏色: (() => {
     let id = 0;
@@ -35,7 +39,7 @@ module.exports = {
       const varName = `__toggleEl${id++}`;
       const color1 = colorMap[c1.replace(/^["']|["']$/g, '')] ? `"${colorMap[c1.replace(/^["']|["']$/g, '')]}"` : c1;
       const color2 = colorMap[c2.replace(/^["']|["']$/g, '')] ? `"${colorMap[c2.replace(/^["']|["']$/g, '')]}"` : c2;
-      return `let ${varName} = document.querySelector(${selector}); ${varName}.style.color = ${varName}.style.color === ${color1} ? ${color2} : ${color1}`;
+      return `let ${varName} = document.querySelector(${selector}); if (${varName}) ${varName}.style.color = ${varName}.style.color === ${color1} ? ${color2} : ${color1}`;
     };
   })()
 };

--- a/textModule.js
+++ b/textModule.js
@@ -1,5 +1,6 @@
 module.exports = {
   設定文字內容: (selector, text) => {
-    return `document.querySelector(${selector}).textContent = ${text}`;
+    const elExpr = `document.querySelector(${selector})`;
+    return `${elExpr} && (${elExpr}.textContent = ${text})`;
   }
 };


### PR DESCRIPTION
## Summary
- guard document.querySelector in styleModule, imageModule, textModule and mediaModule
- adjust tests for the new guards
- add regression test ensuring missing selectors don't throw

## Testing
- `npm test --silent`
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6853d831dd348327b11d0d1dddd044f0