### PR TITLE
Fix unused variable regex and add tests

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -191,8 +191,12 @@ function removeUnusedDeclarations(code) {
   const unusedIdx = new Set();
   for (const { name, idx } of declarations) {
     const esc = name.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
-    const regex = new RegExp(esc, 'g');
-    const matches = codeWithoutComments.match(regex);
+    const regex = new RegExp(`\\b${esc}\\b`, 'g');
+    let matches = codeWithoutComments.match(regex);
+    if (!matches && /[^\w]/.test(name)) {
+      const alt = new RegExp(`(^|[^\\w\\u4e00-\\u9fa5])${esc}([^\\w\\u4e00-\\u9fa5]|$)`, 'g');
+      matches = codeWithoutComments.match(alt);
+    }
     if (!matches || matches.length <= 1) {
       unusedIdx.add(idx);
     }

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -535,6 +535,47 @@ function testRemoveUnusedDeclarations() {
   }
 }
 
+function testSubstringVariablePruning() {
+  const sample = '設定 人物角色 為 2';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(!output.includes('let 人物 ='), 'substring usage should not keep base declaration');
+  assert(output.includes('let 人物角色 = 2;'), 'actual variable declaration should remain');
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
+function testKeepUsedDeclaration() {
+  const sample = '如果(count > 3)：\n  顯示(count)';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(output.includes('let count = 0'), 'used variable declaration should remain');
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testPauseAudioParsing() {
   const sample = '暫停音效(#audio)';
   const originalDemo = fs.readFileSync('demo.blang', 'utf8');
@@ -870,6 +911,8 @@ try {
   testPlayVideoParsing();
   testAutoDeclarePlayerSelector();
   testRemoveUnusedDeclarations();
+  testSubstringVariablePruning();
+  testKeepUsedDeclaration();
   testPauseAudioParsing();
   testPlaySoundParsing();
   testLoopAudioParsing();


### PR DESCRIPTION
## Summary
- tighten regex in `removeUnusedDeclarations` with word boundaries
- handle non-word identifiers so Chinese variable names remain
- test substring variable removal
- test that real usages retain declarations

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6853d833718c8327a0cdeb1c4de350e8