### PR TITLE
Add confirm dialog support

### DIFF
--- a/dialogModule.js
+++ b/dialogModule.js
@@ -1,3 +1,4 @@
 module.exports = {
-  顯示訊息框: (msg) => `alert(${msg})`
+  顯示訊息框: (msg) => `alert(${msg})`,
+  確認: (msg) => `confirm(${msg})`
 };

--- a/grammar.md
+++ b/grammar.md
@@ -46,6 +46,7 @@ Blang 是一種中文語場編程方式，用中文邏輯實現智慧語意互�
 | 物件操作 | 建立人物（"小傑", 25）                  | `let 人物 = { 名字: "小傑", 年齡: 25 }`          |
 |          | 取得屬性（人物, 名字）                  | `人物[名字]`                                    |
 | 輸入輸出 | 顯示訊息框（"內容"）                    | `alert("內容")`                                |
+|          | 確認（"內容"）                          | `confirm("內容")`                    |
 |          | 使用者輸入（"問題？"）                  | `prompt("問題？")`                              |
 |          | 設定文字內容（#id, "文字"）              | `document.querySelector("#id").textContent = "文字"` |
 | 樣式控制 | 設定樣式（#id, 背景色, 紅色）           | `document.querySelector("#id").style["backgroundColor"] = "red"` |

--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -171,6 +171,28 @@ function processCondition(condition) {
   result = processConditionExpression(result)
     // 補強未在 processConditionExpression 中處理的片段
     .replace(/(===|!==|==|!=)\s*空/g, '$1 ""');
+
+  function replaceConfirm(str) {
+    const regex = /確認\s*\(/g;
+    let out = '';
+    let last = 0;
+    let m;
+    while ((m = regex.exec(str))) {
+      out += str.slice(last, m.index) + 'confirm(';
+      let i = regex.lastIndex;
+      let depth = 1;
+      while (i < str.length && depth > 0) {
+        if (str[i] === '(') depth++; else if (str[i] === ')') depth--; i++; }
+      const inner = str.slice(regex.lastIndex, i - 1);
+      out += processDisplayArgument(replaceConfirm(inner), declaredVars) + ')';
+      last = i;
+      regex.lastIndex = i;
+    }
+    out += str.slice(last);
+    return out;
+  }
+
+  result = replaceConfirm(result);
   return result;
 }
 

--- a/patterns/confirm.js
+++ b/patterns/confirm.js
@@ -1,0 +1,3 @@
+module.exports = function registerConfirmPattern(definePattern) {
+  definePattern('確認($訊息)', (訊息) => `confirm(${訊息})`);
+};

--- a/patterns/index.js
+++ b/patterns/index.js
@@ -3,6 +3,7 @@ const displayPatterns = require('./display');
 const mediaPatterns = require('./media');
 const logicPatterns = require('./logic');
 const generalPatterns = require('./general');
+const confirmPattern = require('./confirm');
 
 module.exports = function registerPatterns(definePattern) {
   logicPatterns(definePattern);
@@ -10,4 +11,5 @@ module.exports = function registerPatterns(definePattern) {
   displayPatterns(definePattern);
   mediaPatterns(definePattern);
   generalPatterns(definePattern);
+  confirmPattern(definePattern);
 };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -74,6 +74,31 @@ function testConditionProcessing() {
   }
 }
 
+function testConfirmCondition() {
+  const sample = '如果(確認("確定刪除？"))：\n  顯示("已刪除")';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('if (confirm('),
+    'if statement should use confirm()'
+  );
+  assert(output.includes('確定刪除'), 'message text should be preserved');
+  assert(output.includes('alert("已刪除");'), 'alert line should be present');
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testHideElementParsing() {
   const sample = '隱藏(#test)';
   const originalDemo = fs.readFileSync('demo.blang', 'utf8');
@@ -925,6 +950,7 @@ try {
   testPromptAutoQuoting();
   testParser();
   testConditionProcessing();
+  testConfirmCondition();
   testHideElementParsing();
   testHideParsing();
   testHideShortFormParsing();

--- a/vocabulary_map.json
+++ b/vocabulary_map.json
@@ -31,6 +31,10 @@
         "module": "dialogModule",
         "js": "alert($1)"
     },
+    "確認": {
+        "module": "dialogModule",
+        "js": "confirm($1)"
+    },
     "使用者輸入": {
         "module": "inputModule",
         "js": "prompt($1)"


### PR DESCRIPTION
## Summary
- add `確認` helper to `dialogModule`
- support `確認` in vocabulary map
- handle `確認()` inside conditions
- register new `確認()` pattern
- document confirmation syntax
- test confirmation condition parsing

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_68592a3b11f08327bf3a2b1ac6047b02