### PR TITLE
Add else-if support

### DIFF
--- a/patterns/condition.js
+++ b/patterns/condition.js
@@ -1,0 +1,7 @@
+module.exports = function registerConditionPatterns(definePattern) {
+  definePattern(
+    '否則如果($條件)：',
+    (條件) => `} else if (${條件}) {`,
+    { type: 'control', description: 'else if statement' }
+  );
+};

--- a/patterns/index.js
+++ b/patterns/index.js
@@ -4,6 +4,7 @@ const mediaPatterns = require('./media');
 const logicPatterns = require('./logic');
 const generalPatterns = require('./general');
 const confirmPattern = require('./confirm');
+const conditionPattern = require('./condition');
 
 module.exports = function registerPatterns(definePattern) {
   logicPatterns(definePattern);
@@ -12,4 +13,5 @@ module.exports = function registerPatterns(definePattern) {
   mediaPatterns(definePattern);
   generalPatterns(definePattern);
   confirmPattern(definePattern);
+  conditionPattern(definePattern);
 };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -817,6 +817,26 @@ function testIfElsePatternChinese() {
   );
 }
 
+function testElseIfBlock() {
+  const sample = '如果(數值 > 5)：\n  顯示(">5")\n否則如果(數值 > 3)：\n  顯示(">3")\n否則：\n  顯示("其他")';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(output.includes('} else if (數值 > 3) {'), 'should translate else-if block');
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testAddItemDirectPattern() {
   const sample = '加入項目(A, "蘋果")';
   const originalDemo = fs.readFileSync('demo.blang', 'utf8');
@@ -983,6 +1003,7 @@ try {
   testDisplayDate();
   testIfElsePattern();
   testIfElsePatternChinese();
+  testElseIfBlock();
   testAddItemDirectPattern();
   testGetItemPattern();
   testClearListPattern();


### PR DESCRIPTION
## Summary
- support `否則如果(條件)：` syntax in parser
- expose new pattern for else-if
- wire up new pattern registration
- test else-if branch handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a65e9d62883278a50340d58168ba6