### PR TITLE
Add loop pattern with module

### DIFF
--- a/loopModule.js
+++ b/loopModule.js
@@ -1,0 +1,6 @@
+module.exports = {
+  重複次數執行: (times, jsStatement) => {
+    const stmt = jsStatement.trim().replace(/;?$/, ';');
+    return `for (let i = 0; i < ${times}; i++) { ${stmt} }`;
+  }
+};

--- a/patterns/index.js
+++ b/patterns/index.js
@@ -2,16 +2,18 @@ const arrayPatterns = require('./array');
 const displayPatterns = require('./display');
 const mediaPatterns = require('./media');
 const logicPatterns = require('./logic');
-const generalPatterns = require('./general');
 const confirmPattern = require('./confirm');
 const conditionPattern = require('./condition');
+const loopPatterns = require('./loop');
+const generalPatterns = require('./general');
 
 module.exports = function registerPatterns(definePattern) {
   logicPatterns(definePattern);
   arrayPatterns(definePattern);
   displayPatterns(definePattern);
   mediaPatterns(definePattern);
-  generalPatterns(definePattern);
   confirmPattern(definePattern);
   conditionPattern(definePattern);
+  loopPatterns(definePattern);
+  generalPatterns(definePattern);
 };

--- a/patterns/loop.js
+++ b/patterns/loop.js
@@ -1,0 +1,16 @@
+const loopModule = require('../loopModule.js');
+
+module.exports = function registerLoopPatterns(definePattern) {
+  definePattern(
+    '重複 $次數 次 $語句',
+    (次數, 語句) => {
+      const { runBlangParser } = require('../blangSyntaxAPI.js');
+      let stmt = 語句;
+      const open = (stmt.match(/\(/g) || []).length;
+      const close = (stmt.match(/\)/g) || []).length;
+      if (open > close) stmt += ')';
+      return loopModule.重複次數執行(次數, runBlangParser([stmt]).trim());
+    },
+    { type: 'control', description: 'repeat an action N times' }
+  );
+};

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -726,6 +726,30 @@ function testWaitSecondsDisplay() {
   }
 }
 
+function testRepeatTimes() {
+  const sample = '重複 5 次 顯示("你好")';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(
+    output.includes('for (let i = 0; i < 5; i++) {') &&
+      output.includes('alert("你好");'),
+    '重複 N 次 should translate to for loop with action'
+  );
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testDisplayWeekday() {
   const sample = '顯示今天是星期幾';
   const originalDemo = fs.readFileSync('demo.blang', 'utf8');
@@ -998,6 +1022,7 @@ try {
   testPlaySoundParsing();
   testLoopAudioParsing();
   testWaitSecondsDisplay();
+  testRepeatTimes();
   testDisplayWeekday();
   testDisplayHourMinute();
   testDisplayDate();


### PR DESCRIPTION
## Summary
- add `loopModule.js` exporting loop helper
- define `重複 $次數 次 $語句` pattern using new module
- load loop patterns before general patterns
- test repeating actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a6837aa4c8327883f7ace8f058d2d