### PR TITLE
Add click event parsing to parser

### DIFF
--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -347,6 +347,21 @@ function parseBlang(text) {
     continue;
   }
 
+  if (line.match(/^當[（(](.+?)\.被點擊[）)]時：$/)) {
+    const match = line.match(/^當[（(](.+?)\.被點擊[）)]時：$/);
+    if (match) {
+      const selector = match[1].trim();
+      closeBlocks(indent, nextIndent, line);
+      output.push('');
+      output.push(
+        ' '.repeat(indent) +
+          `document.querySelector(${processDisplayArgument(selector)}).addEventListener("click", () => {`
+      );
+      stack.push({ indent, type: 'event' });
+      continue;
+    }
+  }
+
   if (line.match(/^如果[（(](.*?)\.內容 為 空[）)]：?/)) {
     const match = line.match(/^如果[（(](.*?)\.內容 為 空[）)]：?/);
     if (match) {


### PR DESCRIPTION
## Summary
- support `當(#sel.被點擊)時：` lines in `parser_v0.9.4.js`
- close existing blocks before opening new click event blocks

## Testing
- `npm test`
- `node parser_v0.9.4.js`

------
https://chatgpt.com/codex/tasks/task_e_685a82238d4883278890bbe812b77bfe