### PR TITLE
Switch modules to camelCase exports

### DIFF
--- a/inputModule.js
+++ b/inputModule.js
@@ -1,4 +1,4 @@
 // inputModule.js
 module.exports = {
-  使用者輸入: (問題) => `prompt(${問題})`
+  getInput: (question) => `prompt(${question})`
 };

--- a/semanticHandler-v0.9.4.js
+++ b/semanticHandler-v0.9.4.js
@@ -47,8 +47,13 @@ const FUNC_MAP = {
   讓AI解釋: 'DialogModule.AI回覆',
   '讓 AI 解釋': 'DialogModule.AI回覆',
   顯示訊息框: 'DialogModule.顯示訊息框',
-  播放音效: 'soundModule.播放音效',
-  設定樣式: 'StyleModule.設定樣式'
+  播放音效: 'soundModule.playSound',
+  設定樣式: 'StyleModule.setStyle',
+  顯示: 'StyleModule.show',
+  隱藏: 'StyleModule.hide',
+  隱藏元素: 'StyleModule.hide',
+  設定背景色: 'StyleModule.setBackgroundColor',
+  切換顏色: 'StyleModule.toggleColor'
 };
 
 // ✅ 括號、引號、問號的統一處理（全形→半形）
@@ -267,11 +272,13 @@ function handleFunctionCall(funcName, params, indent = 0, declaredVars = new Set
     });
 
     const mod = modules[moduleName];
-    if (mod && typeof mod[funcName] === 'function') {
+    const mapped = FUNC_MAP[funcName];
+    const method = mapped ? mapped.split('.').pop() : funcName;
+    if (mod && typeof mod[method] === 'function') {
       try {
-        return `${space}${mod[funcName](...args)};`;
+        return `${space}${mod[method](...args)};`;
       } catch (e) {
-        console.warn(`⚠️ 模組 ${moduleName}.${funcName} 錯誤`, e);
+        console.warn(`⚠️ 模組 ${moduleName}.${method} 錯誤`, e);
       }
     }
     return `${space}${applyTemplate(jsTemplate, args)};`;

--- a/soundModule.js
+++ b/soundModule.js
@@ -1,3 +1,3 @@
 module.exports = {
-  播放音效: (src) => `new Audio(${src}).play()`
+  playSound: (src) => `new Audio(${src}).play()`
 };

--- a/styleModule.js
+++ b/styleModule.js
@@ -6,7 +6,7 @@ const hide = (selector) => {
 };
 
 module.exports = {
-  設定樣式: (selector, styleProp, value) => {
+  setStyle: (selector, styleProp, value) => {
     const propMap = {
       背景色: 'backgroundColor',
       文字顏色: 'color',
@@ -22,18 +22,18 @@ module.exports = {
     const elExpr = `document.querySelector(${selector})`;
     return `${elExpr} && (${elExpr}.style["${cleanProp}"] = "${cleanValue}")`;
   },
-  隱藏: hide,
-  隱藏元素: hide,
-  顯示: (selector) => {
+  hide: hide,
+  hideElement: hide,
+  show: (selector) => {
     const elExpr = `document.querySelector(${selector})`;
     return `${elExpr} && (${elExpr}.style.display = "block")`;
   },
-  設定背景色: (selector, color) => {
+  setBackgroundColor: (selector, color) => {
     const cleanColor = color.replace(/^['"]|['"]$/g, '');
     const elExpr = `document.querySelector(${selector})`;
     return `${elExpr} && (${elExpr}.style.backgroundColor = "${cleanColor}")`;
   },
-  切換顏色: (() => {
+  toggleColor: (() => {
     let id = 0;
     return (selector, c1, c2) => {
       const varName = `__toggleEl${id++}`;

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -383,7 +383,7 @@ function testSetSelectorContent() {
 
 function testSelectorGuard() {
   const vm = require('vm');
-  const code = styleModule.隱藏('"#missing"');
+  const code = styleModule.hide('"#missing"');
   assert.doesNotThrow(
     () => vm.runInNewContext(code + ';', { document: { querySelector: () => null } }),
     'styleModule functions should guard against missing elements'

--- a/timeModule.js
+++ b/timeModule.js
@@ -1,8 +1,8 @@
 module.exports = {
-  獲取現在時間: () => 'new Date().toLocaleTimeString()',
-  顯示現在時間: () => 'alert(new Date().toLocaleString())',
-  顯示今天是星期幾: () =>
+  getCurrentTime: () => 'new Date().toLocaleTimeString()',
+  showCurrentTime: () => 'alert(new Date().toLocaleString())',
+  showDayOfWeek: () =>
     'alert("今天是星期" + "日一二三四五六"[new Date().getDay()])',
-  顯示現在是幾點幾分: () =>
+  showHourMinute: () =>
     'alert("現在是" + new Date().getHours() + "點" + new Date().getMinutes() + "分")'
 };

--- a/vocabulary_map.json
+++ b/vocabulary_map.json
@@ -45,11 +45,11 @@
     },
     "設定樣式": {
         "module": "styleModule",
-        "js": "styleModule.設定樣式($1, $2, $3)"
+        "js": "styleModule.setStyle($1, $2, $3)"
     },
     "設定背景色": {
         "module": "styleModule",
-        "js": "styleModule.設定背景色($1, $2)"
+        "js": "styleModule.setBackgroundColor($1, $2)"
     },
     "建立物件": {
         "module": "objectModule",
@@ -73,19 +73,19 @@
     },
     "切換顏色": {
         "module": "styleModule",
-        "js": ""
+        "js": "styleModule.toggleColor($1, $2, $3)"
     },
     "隱藏元素": {
         "module": "styleModule",
-        "js": "styleModule.隱藏($1)"
+        "js": "styleModule.hide($1)"
     },
     "隱藏": {
         "module": "styleModule",
-        "js": "styleModule.隱藏($1)"
+        "js": "styleModule.hide($1)"
     },
     "顯示": {
         "module": "styleModule",
-        "js": "styleModule.顯示($1)"
+        "js": "styleModule.show($1)"
     },
     "切換顯示隱藏": {
         "module": "styleModule",


### PR DESCRIPTION
## Summary
- rename module exports to English camelCase
- update semantic handler function map to match
- adjust vocabulary map and unit tests

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_685be0bab3bc832780ea2a863ed86a48