### PR TITLE
Add for-each loop syntax

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -9,23 +9,55 @@
 
   function parseBlang(code){
     const lines = Array.isArray(code) ? code : String(code).split(/\r?\n/);
-    let result;
-    try {
-      result = runBlangParser(lines).trim();
-    } catch(err){
-      const msg = ErrorHelper && ErrorHelper.translateError ?
-        ErrorHelper.translateError(err) : (err && err.message) || String(err);
-      throw new Error(msg);
+    const output = [];
+    const stack = [];
+    const multiLine = lines.length > 1;
+
+    for (let i = 0; i < lines.length; i++) {
+      const raw = lines[i];
+      const indent = raw.match(/^\s*/)[0].length;
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+
+      while (stack.length && indent < stack[stack.length - 1]) {
+        const last = stack.pop();
+        output.push(' '.repeat(last) + '}');
+      }
+
+      const eachMatch = trimmed.match(/^對每個\s+(.+?)\s+在\s+(.+?)\s*做：$/);
+      if (eachMatch) {
+        output.push(' '.repeat(indent) + `for (let ${eachMatch[1]} of ${eachMatch[2]}) {`);
+        stack.push(indent);
+        continue;
+      }
+
+      let result;
+      try {
+        result = runBlangParser([trimmed]).trim();
+      } catch(err){
+        const msg = ErrorHelper && ErrorHelper.translateError ?
+          ErrorHelper.translateError(err) : (err && err.message) || String(err);
+        throw new Error(msg);
+      }
+      if(result.startsWith('// 無法辨識語句')){
+        const msg = ErrorHelper && ErrorHelper.translateError ?
+          ErrorHelper.translateError(new Error(result)) : result;
+        const err = new Error(msg);
+        const m = result.match(/是否想輸入：(.+?)\?/);
+        if(m) err.suggestion = m[1];
+        throw err;
+      }
+      output.push(' '.repeat(indent) + result);
     }
-    if(result.startsWith('// 無法辨識語句')){
-      const msg = ErrorHelper && ErrorHelper.translateError ?
-        ErrorHelper.translateError(new Error(result)) : result;
-      const err = new Error(msg);
-      const m = result.match(/是否想輸入：(.+?)\?/);
-      if(m) err.suggestion = m[1];
-      throw err;
+
+    while (stack.length) {
+      const last = stack.pop();
+      if (multiLine) {
+        output.push(' '.repeat(last) + '}');
+      }
     }
-    return result;
+
+    return output.join('\n');
   }
 
   return parseBlang;

--- a/parser_v0.9.4.js
+++ b/parser_v0.9.4.js
@@ -329,6 +329,17 @@ function parseBlang(text) {
       }
     }
 
+    if (line.match(/^對每個\s+(.+?)\s+在\s+(.+?)\s*做：$/)) {
+      closeBlocks(indent, nextIndent, line);
+      const match = line.match(/^對每個\s+(.+?)\s+在\s+(.+?)\s*做：$/);
+      const item = match[1].trim();
+      const list = match[2].trim();
+      declaredVars.add(item);
+      output.push(' '.repeat(indent) + `for (let ${item} of ${list}) {`);
+      stack.push({ indent, type: 'loop' });
+      continue;
+    }
+
     function handleEvent(line, eventType, domTarget, jsEvent) {
       if (line === `當(${domTarget})時：`) {
         if (registeredEvents.has(eventType)) return true;
@@ -801,18 +812,9 @@ function parseBlang(text) {
 if (isNode) {
   module.exports.parseBlang = parseBlang;
   if (require.main === module) {
-    const skeleton = [
-      "const { 處理送出事件 } = require('./eventModule.js');",
-      "const { 啟動程式流程 } = require('./logicModule.js');",
-      "const { 設定初始樣式 } = require('./styleModule.js');",
-      'function 啟動語法引擎() {',
-      '  設定初始樣式();',
-      '  處理送出事件();',
-      '  啟動程式流程();',
-      '}',
-      '啟動語法引擎();'
-    ].join('\n');
-    fs.writeFileSync('output.js', skeleton);
+    const input = fs.readFileSync('demo.blang', 'utf8');
+    const code = parseBlang(input);
+    fs.writeFileSync('output.js', code);
     console.log('✅ 腦語 parser v0.9.4（全檔案變數掃描補宣告）已成功轉譯');
   }
 } else {

--- a/patterns/loop.js
+++ b/patterns/loop.js
@@ -13,4 +13,10 @@ module.exports = function registerLoopPatterns(definePattern) {
     },
     { type: 'control', description: 'repeat an action N times' }
   );
+
+  definePattern(
+    '對每個 $項 在 $清單 做：',
+    (項, 清單) => `for (let ${項} of ${清單}) {`,
+    { type: 'control', description: 'iterate over items in a list' }
+  );
 };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -752,6 +752,28 @@ function testRepeatTimes() {
   }
 }
 
+function testForEachLoop() {
+  const sample = '對每個 水果 在 水果們 做：\n  顯示(水果)\n  顯示("----")';
+  const originalDemo = fs.readFileSync('demo.blang', 'utf8');
+  fs.writeFileSync('demo.blang', sample);
+
+  const hasOutput = fs.existsSync('output.js');
+  const originalOut = hasOutput ? fs.readFileSync('output.js', 'utf8') : null;
+
+  execSync('node parser_v0.9.4.js');
+  const output = fs.readFileSync('output.js', 'utf8');
+  assert(output.includes('for (let 水果 of 水果們) {'), 'for-each loop should translate to for...of');
+  assert(output.includes('alert(水果);'), 'loop body should include first statement');
+  assert(output.includes('alert("----");'), 'loop body should include second statement');
+
+  fs.writeFileSync('demo.blang', originalDemo);
+  if (hasOutput) {
+    fs.writeFileSync('output.js', originalOut);
+  } else {
+    fs.unlinkSync('output.js');
+  }
+}
+
 function testDisplayWeekday() {
   const sample = '顯示今天是星期幾';
   const originalDemo = fs.readFileSync('demo.blang', 'utf8');
@@ -1064,6 +1086,7 @@ try {
   testLoopAudioParsing();
   testWaitSecondsDisplay();
   testRepeatTimes();
+  testForEachLoop();
   testDisplayWeekday();
   testDisplayHourMinute();
   testDisplayDate();

--- a/tests/syntaxExamples.test.js
+++ b/tests/syntaxExamples.test.js
@@ -28,6 +28,10 @@ function testSyntaxExamples() {
       phrase: '顯示(輸入框.內容)',
       expected: 'alert(輸入框.內容);'
     }
+    , {
+      phrase: '對每個 數字 在 數列 做：',
+      expected: 'for (let 數字 of 數列) {'
+    }
   ];
 
   cases.forEach(({ phrase, expected }) => {


### PR DESCRIPTION
## Summary
- add `對每個` for-each loop pattern
- parse for-each blocks in parser and parser_v0.9.4
- handle indentation blocks in parser.js
- test for new loop syntax
- ensure CLI parser parses `demo.blang`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861180ad1288327882f430b6682e8bf